### PR TITLE
Removing `go.mod` for v3 releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          path: src/github.com/golang-jwt/jwt
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
@@ -26,3 +28,6 @@ jobs:
           go vet ./...
           go test -v ./...
           go build ./...
+        env:
+          GO111MODULE: auto
+          GOPATH: ${{ github.workspace }}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,0 @@
-module github.com/golang-jwt/jwt
-
-go 1.14
-


### PR DESCRIPTION
As discussed in full length here (#17), we have run into issues that forces us to abandon go modules, at least for the `v3.x.x` releases. After this is merged in, we can release a `v3.2.1+incompatible` version, which contains a security fix. 

Afterwards, we will work on non-breaking quality of life fixes and then eventually run a `v4` version, which most likely will then support go modules and have a new SIV-style import path.

Also note that according to https://blog.golang.org/go116-module-changes, building from $GOPATH will be *removed* in Go 1.17. So most likely, only the `v4` SIV-style releases will be supported by Go 1.17. However, I can not find anything with regards to this on the upcoming release notes (http://tip.golang.org/doc/go1.17)