### PR TITLE
Allocation optimization

### DIFF
--- a/ecdsa.go
+++ b/ecdsa.go
@@ -128,18 +128,12 @@ func (m *SigningMethodECDSA) Sign(signingString string, key interface{}) (string
 			keyBytes += 1
 		}
 
-		// We serialize the outpus (r and s) into big-endian byte arrays and pad
-		// them with zeros on the left to make sure the sizes work out. Both arrays
-		// must be keyBytes long, and the output must be 2*keyBytes long.
-		rBytes := r.Bytes()
-		rBytesPadded := make([]byte, keyBytes)
-		copy(rBytesPadded[keyBytes-len(rBytes):], rBytes)
-
-		sBytes := s.Bytes()
-		sBytesPadded := make([]byte, keyBytes)
-		copy(sBytesPadded[keyBytes-len(sBytes):], sBytes)
-
-		out := append(rBytesPadded, sBytesPadded...)
+		// We serialize the outputs (r and s) into big-endian byte arrays
+		// padded with zeros on the left to make sure the sizes work out.
+		// Output must be 2*keyBytes long.
+		out := make([]byte, 2*keyBytes)
+		r.FillBytes(out[0:keyBytes]) // r is assigned to the first half of output.
+		s.FillBytes(out[keyBytes:])  // s is assigned to the second half of output.
 
 		return EncodeSegment(out), nil
 	} else {

--- a/ecdsa_test.go
+++ b/ecdsa_test.go
@@ -87,13 +87,20 @@ func TestECDSASign(t *testing.T) {
 
 		if data.valid {
 			parts := strings.Split(data.tokenString, ".")
+			toSign := strings.Join(parts[0:2], ".")
 			method := jwt.GetSigningMethod(data.alg)
-			sig, err := method.Sign(strings.Join(parts[0:2], "."), ecdsaKey)
+			sig, err := method.Sign(toSign, ecdsaKey)
+
 			if err != nil {
 				t.Errorf("[%v] Error signing token: %v", data.name, err)
 			}
 			if sig == parts[2] {
 				t.Errorf("[%v] Identical signatures\nbefore:\n%v\nafter:\n%v", data.name, parts[2], sig)
+			}
+
+			err = method.Verify(toSign, sig, ecdsaKey.Public())
+			if err != nil {
+				t.Errorf("[%v] Sign produced an invalid signature: %v", data.name, err)
 			}
 		}
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -290,6 +290,8 @@ func TestParser_ParseUnverified(t *testing.T) {
 // Helper method for benchmarking various methods
 func benchmarkSigning(b *testing.B, method jwt.SigningMethod, key interface{}) {
 	t := jwt.New(method)
+	b.ReportAllocs()
+	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			if _, err := t.SignedString(key); err != nil {

--- a/token.go
+++ b/token.go
@@ -95,14 +95,10 @@ func ParseWithClaims(tokenString string, claims Claims, keyFunc Keyfunc) (*Token
 
 // Encode JWT specific base64url encoding with padding stripped
 func EncodeSegment(seg []byte) string {
-	return strings.TrimRight(base64.URLEncoding.EncodeToString(seg), "=")
+	return base64.RawURLEncoding.EncodeToString(seg)
 }
 
 // Decode JWT specific base64url encoding with padding stripped
 func DecodeSegment(seg string) ([]byte, error) {
-	if l := len(seg) % 4; l > 0 {
-		seg += strings.Repeat("=", 4-l)
-	}
-
-	return base64.URLEncoding.DecodeString(seg)
+	return base64.RawURLEncoding.DecodeString(seg)
 }


### PR DESCRIPTION
Add benchmark coverage of ECDSA signing methods.

Reduce memory allocations for ECDSA signing by using [big.Int.FillBytes](https://golang.org/pkg/math/big/#Int.FillBytes
) instead of allocating and copying bytes directly.
`FillBytes` was added in go 1.15.
> FillBytes sets buf to the absolute value of x, storing it as a zero-extended big-endian byte slice, and returns buf.

Use [base64.RawURLEncoding](https://golang.org/pkg/encoding/base64/#pkg-variables) to avoid having to add and remove `=` padding.
> RawURLEncoding ... is the same as URLEncoding but omits padding characters.

## Benchmark results

```
$ go test --bench=Bench --run=NONE .
goos: darwin
goarch: amd64
pkg: github.com/golang-jwt/jwt
```

Before optimizations, as of ff7295fc94e1d37ba46fd2a0ce9f10454551a2e2:
```
BenchmarkECDSASigning/Basic_ES256-8                     178389      7499 ns/op    4249 B/op      65 allocs/op
BenchmarkECDSASigning/Basic_ES256/sign-only-8            47665     26629 ns/op    3329 B/op      43 allocs/op
BenchmarkECDSASigning/basic_ES256_invalid:_foo_=>_bar-8 135355      7830 ns/op    4249 B/op      65 allocs/op
BenchmarkHS256Signing-8                                1000000      1369 ns/op    1584 B/op      32 allocs/op
BenchmarkHS384Signing-8                                 847502      1628 ns/op    1969 B/op      32 allocs/op
BenchmarkHS512Signing-8                                 772740      1599 ns/op    2065 B/op      32 allocs/op
BenchmarkRS256Signing-8                                   2834    414766 ns/op   32575 B/op     136 allocs/op
BenchmarkRS384Signing-8                                   2918    388103 ns/op   32688 B/op     136 allocs/op
BenchmarkRS512Signing-8                                   3238    371378 ns/op   32707 B/op     136 allocs/op
```

After optimizations:
```
BenchmarkECDSASigning/Basic_ES256-8                     153951      8351 ns/op    4021 B/op      58 allocs/op
BenchmarkECDSASigning/Basic_ES256/sign-only-8            48044     25095 ns/op    3169 B/op      38 allocs/op
BenchmarkECDSASigning/basic_ES256_invalid:_foo_=>_bar-8 148740      9228 ns/op    4021 B/op      58 allocs/op
BenchmarkHS256Signing-8                                1000000      1167 ns/op    1488 B/op      29 allocs/op
BenchmarkHS384Signing-8                                 959800      1424 ns/op    1873 B/op      29 allocs/op
BenchmarkHS512Signing-8                                 902449      1603 ns/op    1969 B/op      29 allocs/op
BenchmarkRS256Signing-8                                   2731    443249 ns/op   32476 B/op     133 allocs/op
BenchmarkRS384Signing-8                                   2472    420263 ns/op   32587 B/op     133 allocs/op
BenchmarkRS512Signing-8                                   2840    409993 ns/op   32614 B/op     133 allocs/op
```

Output of `BenchmarkECDSASigning` with ES384 and ES512 are omitted because the
allocations change for each execution.