### PR TITLE
Remove init functions by adding functions for creating new SigningMet…

### DIFF
--- a/ecdsa.go
+++ b/ecdsa.go
@@ -30,7 +30,7 @@ var (
 )
 
 // NewSigningMethodECDSA creates a new SigningMethodECDSA struct and
-// registers it with RegisterSigningMethod.
+// registers it as a signing method.
 func NewSigningMethodECDSA(name string, hash crypto.Hash, keySize, curveBits int) *SigningMethodECDSA {
 	m := &SigningMethodECDSA{name, hash, keySize, curveBits}
 	Register(m)

--- a/ecdsa.go
+++ b/ecdsa.go
@@ -24,29 +24,17 @@ type SigningMethodECDSA struct {
 
 // Specific instances for EC256 and company
 var (
-	SigningMethodES256 *SigningMethodECDSA
-	SigningMethodES384 *SigningMethodECDSA
-	SigningMethodES512 *SigningMethodECDSA
+	SigningMethodES256 = NewSigningMethodECDSA("ES256", crypto.SHA256, 32, 256)
+	SigningMethodES384 = NewSigningMethodECDSA("ES384", crypto.SHA384, 48, 384)
+	SigningMethodES512 = NewSigningMethodECDSA("ES512", crypto.SHA512, 66, 521)
 )
 
-func init() {
-	// ES256
-	SigningMethodES256 = &SigningMethodECDSA{"ES256", crypto.SHA256, 32, 256}
-	RegisterSigningMethod(SigningMethodES256.Alg(), func() SigningMethod {
-		return SigningMethodES256
-	})
-
-	// ES384
-	SigningMethodES384 = &SigningMethodECDSA{"ES384", crypto.SHA384, 48, 384}
-	RegisterSigningMethod(SigningMethodES384.Alg(), func() SigningMethod {
-		return SigningMethodES384
-	})
-
-	// ES512
-	SigningMethodES512 = &SigningMethodECDSA{"ES512", crypto.SHA512, 66, 521}
-	RegisterSigningMethod(SigningMethodES512.Alg(), func() SigningMethod {
-		return SigningMethodES512
-	})
+// NewSigningMethodECDSA creates a new SigningMethodECDSA struct and
+// registers it with RegisterSigningMethod.
+func NewSigningMethodECDSA(name string, hash crypto.Hash, keySize, curveBits int) *SigningMethodECDSA {
+	m := &SigningMethodECDSA{name, hash, keySize, curveBits}
+	Register(m)
+	return m
 }
 
 func (m *SigningMethodECDSA) Alg() string {
@@ -56,11 +44,10 @@ func (m *SigningMethodECDSA) Alg() string {
 // Verify implements token verification for the SigningMethod.
 // For this verify method, key must be an ecdsa.PublicKey struct
 func (m *SigningMethodECDSA) Verify(signingString, signature string, key interface{}) error {
-	var err error
 
 	// Decode the signature
-	var sig []byte
-	if sig, err = DecodeSegment(signature); err != nil {
+	sig, err := DecodeSegment(signature)
+	if err != nil {
 		return err
 	}
 
@@ -96,7 +83,7 @@ func (m *SigningMethodECDSA) Verify(signingString, signature string, key interfa
 }
 
 // Sign implements token signing for the SigningMethod.
-// For this signing method, key must be an ecdsa.PrivateKey struct
+// For this signing method, the key must be an ecdsa.PrivateKey struct.
 func (m *SigningMethodECDSA) Sign(signingString string, key interface{}) (string, error) {
 	// Get the key
 	var ecdsaKey *ecdsa.PrivateKey
@@ -115,28 +102,29 @@ func (m *SigningMethodECDSA) Sign(signingString string, key interface{}) (string
 	hasher := m.Hash.New()
 	hasher.Write([]byte(signingString))
 
-	// Sign the string and return r, s
-	if r, s, err := ecdsa.Sign(rand.Reader, ecdsaKey, hasher.Sum(nil)); err == nil {
-		curveBits := ecdsaKey.Curve.Params().BitSize
-
-		if m.CurveBits != curveBits {
-			return "", ErrInvalidKey
-		}
-
-		keyBytes := curveBits / 8
-		if curveBits%8 > 0 {
-			keyBytes += 1
-		}
-
-		// We serialize the outputs (r and s) into big-endian byte arrays
-		// padded with zeros on the left to make sure the sizes work out.
-		// Output must be 2*keyBytes long.
-		out := make([]byte, 2*keyBytes)
-		r.FillBytes(out[0:keyBytes]) // r is assigned to the first half of output.
-		s.FillBytes(out[keyBytes:])  // s is assigned to the second half of output.
-
-		return EncodeSegment(out), nil
-	} else {
+	// Sign the string
+	r, s, err := ecdsa.Sign(rand.Reader, ecdsaKey, hasher.Sum(nil))
+	if err != nil {
 		return "", err
 	}
+
+	curveBits := ecdsaKey.Curve.Params().BitSize
+
+	if m.CurveBits != curveBits {
+		return "", ErrInvalidKey
+	}
+
+	keyBytes := curveBits / 8
+	if curveBits%8 > 0 {
+		keyBytes++
+	}
+
+	// We serialize the outputs (r and s) into big-endian byte arrays
+	// padded with zeros on the left to make sure the sizes work out.
+	// Output must be 2*keyBytes long.
+	out := make([]byte, 2*keyBytes)
+	r.FillBytes(out[0:keyBytes]) // r is assigned to the first half of output.
+	s.FillBytes(out[keyBytes:])  // s is assigned to the second half of output.
+
+	return EncodeSegment(out), nil
 }

--- a/ecdsa.go
+++ b/ecdsa.go
@@ -24,14 +24,14 @@ type SigningMethodECDSA struct {
 
 // Specific instances for EC256 and company
 var (
-	SigningMethodES256 = NewSigningMethodECDSA("ES256", crypto.SHA256, 32, 256)
-	SigningMethodES384 = NewSigningMethodECDSA("ES384", crypto.SHA384, 48, 384)
-	SigningMethodES512 = NewSigningMethodECDSA("ES512", crypto.SHA512, 66, 521)
+	SigningMethodES256 = newSigningMethodECDSA("ES256", crypto.SHA256, 32, 256)
+	SigningMethodES384 = newSigningMethodECDSA("ES384", crypto.SHA384, 48, 384)
+	SigningMethodES512 = newSigningMethodECDSA("ES512", crypto.SHA512, 66, 521)
 )
 
-// NewSigningMethodECDSA creates a new SigningMethodECDSA struct and
+// newSigningMethodECDSA creates a new SigningMethodECDSA struct and
 // registers it as a signing method.
-func NewSigningMethodECDSA(name string, hash crypto.Hash, keySize, curveBits int) *SigningMethodECDSA {
+func newSigningMethodECDSA(name string, hash crypto.Hash, keySize, curveBits int) *SigningMethodECDSA {
 	m := &SigningMethodECDSA{name, hash, keySize, curveBits}
 	Register(m)
 	return m

--- a/ed25519.go
+++ b/ed25519.go
@@ -15,11 +15,11 @@ var (
 type SigningMethodEd25519 struct{}
 
 // SigningMethodEdDSA is a specific instance of SigningMethodEd25519 for EdDSA
-var SigningMethodEdDSA = NewSigningMethodEd25519()
+var SigningMethodEdDSA = newSigningMethodEd25519()
 
-// NewSigningMethodEd25519 creates a new SigningMethodEd25519 struct and
+// newSigningMethodEd25519 creates a new SigningMethodEd25519 struct and
 // registers it as a signing method.
-func NewSigningMethodEd25519() *SigningMethodEd25519 {
+func newSigningMethodEd25519() *SigningMethodEd25519 {
 	m := &SigningMethodEd25519{}
 	Register(m)
 	return m

--- a/ed25519.go
+++ b/ed25519.go
@@ -14,16 +14,15 @@ var (
 // Expects ed25519.PrivateKey for signing and ed25519.PublicKey for verification
 type SigningMethodEd25519 struct{}
 
-// Specific instance for EdDSA
-var (
-	SigningMethodEdDSA *SigningMethodEd25519
-)
+// SigningMethodEdDSA is a specific instance of SigningMethodEd25519 for EdDSA
+var SigningMethodEdDSA = NewSigningMethodEd25519()
 
-func init() {
-	SigningMethodEdDSA = &SigningMethodEd25519{}
-	RegisterSigningMethod(SigningMethodEdDSA.Alg(), func() SigningMethod {
-		return SigningMethodEdDSA
-	})
+// NewSigningMethodEd25519 creates a new SigningMethodEd25519 struct and
+// registers it with RegisterSigningMethod.
+func NewSigningMethodEd25519() *SigningMethodEd25519 {
+	m := &SigningMethodEd25519{}
+	Register(m)
+	return m
 }
 
 func (m *SigningMethodEd25519) Alg() string {

--- a/ed25519.go
+++ b/ed25519.go
@@ -18,7 +18,7 @@ type SigningMethodEd25519 struct{}
 var SigningMethodEdDSA = NewSigningMethodEd25519()
 
 // NewSigningMethodEd25519 creates a new SigningMethodEd25519 struct and
-// registers it with RegisterSigningMethod.
+// registers it as a signing method.
 func NewSigningMethodEd25519() *SigningMethodEd25519 {
 	m := &SigningMethodEd25519{}
 	Register(m)

--- a/hmac.go
+++ b/hmac.go
@@ -15,30 +15,18 @@ type SigningMethodHMAC struct {
 
 // Specific instances for HS256 and company
 var (
-	SigningMethodHS256  *SigningMethodHMAC
-	SigningMethodHS384  *SigningMethodHMAC
-	SigningMethodHS512  *SigningMethodHMAC
+	SigningMethodHS256  = NewSigningMethodHMAC("HS256", crypto.SHA256)
+	SigningMethodHS384  = NewSigningMethodHMAC("HS384", crypto.SHA384)
+	SigningMethodHS512  = NewSigningMethodHMAC("HS512", crypto.SHA512)
 	ErrSignatureInvalid = errors.New("signature is invalid")
 )
 
-func init() {
-	// HS256
-	SigningMethodHS256 = &SigningMethodHMAC{"HS256", crypto.SHA256}
-	RegisterSigningMethod(SigningMethodHS256.Alg(), func() SigningMethod {
-		return SigningMethodHS256
-	})
-
-	// HS384
-	SigningMethodHS384 = &SigningMethodHMAC{"HS384", crypto.SHA384}
-	RegisterSigningMethod(SigningMethodHS384.Alg(), func() SigningMethod {
-		return SigningMethodHS384
-	})
-
-	// HS512
-	SigningMethodHS512 = &SigningMethodHMAC{"HS512", crypto.SHA512}
-	RegisterSigningMethod(SigningMethodHS512.Alg(), func() SigningMethod {
-		return SigningMethodHS512
-	})
+// NewSigningMethodHMAC creates a new SigningMethodHMAC struct and
+// registers it with RegisterSigningMethod.
+func NewSigningMethodHMAC(name string, hash crypto.Hash) *SigningMethodHMAC {
+	m := &SigningMethodHMAC{name, hash}
+	Register(m)
+	return m
 }
 
 func (m *SigningMethodHMAC) Alg() string {

--- a/hmac.go
+++ b/hmac.go
@@ -15,15 +15,15 @@ type SigningMethodHMAC struct {
 
 // Specific instances for HS256 and company
 var (
-	SigningMethodHS256  = NewSigningMethodHMAC("HS256", crypto.SHA256)
-	SigningMethodHS384  = NewSigningMethodHMAC("HS384", crypto.SHA384)
-	SigningMethodHS512  = NewSigningMethodHMAC("HS512", crypto.SHA512)
+	SigningMethodHS256  = newSigningMethodHMAC("HS256", crypto.SHA256)
+	SigningMethodHS384  = newSigningMethodHMAC("HS384", crypto.SHA384)
+	SigningMethodHS512  = newSigningMethodHMAC("HS512", crypto.SHA512)
 	ErrSignatureInvalid = errors.New("signature is invalid")
 )
 
-// NewSigningMethodHMAC creates a new SigningMethodHMAC struct and
+// newSigningMethodHMAC creates a new SigningMethodHMAC struct and
 // registers it as a signing method.
-func NewSigningMethodHMAC(name string, hash crypto.Hash) *SigningMethodHMAC {
+func newSigningMethodHMAC(name string, hash crypto.Hash) *SigningMethodHMAC {
 	m := &SigningMethodHMAC{name, hash}
 	Register(m)
 	return m

--- a/hmac.go
+++ b/hmac.go
@@ -22,7 +22,7 @@ var (
 )
 
 // NewSigningMethodHMAC creates a new SigningMethodHMAC struct and
-// registers it with RegisterSigningMethod.
+// registers it as a signing method.
 func NewSigningMethodHMAC(name string, hash crypto.Hash) *SigningMethodHMAC {
 	m := &SigningMethodHMAC{name, hash}
 	Register(m)

--- a/map_claims_test.go
+++ b/map_claims_test.go
@@ -7,54 +7,51 @@ import (
 func TestVerifyAud(t *testing.T) {
 	var nilInterface interface{}
 	var nilListInterface []interface{}
-	var intListInterface interface{} = []int{1,2,3}
-	type test struct{
-		Name string
-		MapClaims MapClaims
-		Expected bool
+	var intListInterface interface{} = []int{1, 2, 3}
+	type test struct {
+		Name       string
+		MapClaims  MapClaims
+		Expected   bool
 		Comparison string
-		Required bool
+		Required   bool
 	}
 	tests := []test{
 		// Matching Claim in aud
 		// Required = true
-		{ Name: "String Aud matching required", MapClaims: MapClaims{"aud": "example.com"}, Expected: true , Required: true, Comparison: "example.com"},
-		{ Name: "[]String Aud with match required", MapClaims: MapClaims{"aud": []string{"example.com", "example.example.com"}}, Expected: true, Required: true, Comparison: "example.com"},
+		{Name: "String Aud matching required", MapClaims: MapClaims{"aud": "example.com"}, Expected: true, Required: true, Comparison: "example.com"},
+		{Name: "[]String Aud with match required", MapClaims: MapClaims{"aud": []string{"example.com", "example.example.com"}}, Expected: true, Required: true, Comparison: "example.com"},
 
 		// Required = false
-		{ Name: "String Aud with match not required", MapClaims: MapClaims{"aud": "example.com"}, Expected: true , Required: false, Comparison: "example.com"},
-		{ Name: "Empty String Aud with match not required", MapClaims: MapClaims{}, Expected: true , Required: false, Comparison: "example.com"},
-		{ Name: "Empty String Aud with match not required", MapClaims: MapClaims{"aud": ""}, Expected: true , Required: false, Comparison: "example.com"},
-		{ Name: "Nil String Aud with match not required", MapClaims: MapClaims{"aud": nil}, Expected: true , Required: false, Comparison: "example.com"},
+		{Name: "String Aud with match not required", MapClaims: MapClaims{"aud": "example.com"}, Expected: true, Required: false, Comparison: "example.com"},
+		{Name: "Empty String Aud with match not required", MapClaims: MapClaims{}, Expected: true, Required: false, Comparison: "example.com"},
+		{Name: "Empty String Aud with match not required", MapClaims: MapClaims{"aud": ""}, Expected: true, Required: false, Comparison: "example.com"},
+		{Name: "Nil String Aud with match not required", MapClaims: MapClaims{"aud": nil}, Expected: true, Required: false, Comparison: "example.com"},
 
-		{ Name: "[]String Aud with match not required", MapClaims: MapClaims{"aud": []string{"example.com", "example.example.com"}}, Expected: true, Required: false, Comparison: "example.com"},
-		{ Name: "Empty []String Aud with match not required", MapClaims: MapClaims{"aud": []string{}}, Expected: true, Required: false, Comparison: "example.com"},
+		{Name: "[]String Aud with match not required", MapClaims: MapClaims{"aud": []string{"example.com", "example.example.com"}}, Expected: true, Required: false, Comparison: "example.com"},
+		{Name: "Empty []String Aud with match not required", MapClaims: MapClaims{"aud": []string{}}, Expected: true, Required: false, Comparison: "example.com"},
 
 		// Non-Matching Claim in aud
 		// Required = true
-		{ Name: "String Aud without match required", MapClaims: MapClaims{"aud": "not.example.com"}, Expected: false, Required: true, Comparison: "example.com"},
-		{ Name: "Empty String Aud without match required", MapClaims: MapClaims{"aud": ""}, Expected: false, Required: true, Comparison: "example.com"},
-		{ Name: "[]String Aud without match required", MapClaims: MapClaims{"aud": []string{"not.example.com", "example.example.com"}}, Expected: false, Required: true, Comparison: "example.com"},
-		{ Name: "Empty []String Aud without match required", MapClaims: MapClaims{"aud": []string{""}}, Expected: false, Required: true, Comparison: "example.com"},
-		{ Name: "String Aud without match not required", MapClaims: MapClaims{"aud": "not.example.com"}, Expected: false, Required: true, Comparison: "example.com"},
-		{ Name: "Empty String Aud without match not required", MapClaims: MapClaims{"aud": ""}, Expected: false, Required: true, Comparison: "example.com"},
-		{ Name: "[]String Aud without match not required", MapClaims: MapClaims{"aud": []string{"not.example.com", "example.example.com"}}, Expected: false, Required: true, Comparison: "example.com"},
+		{Name: "String Aud without match required", MapClaims: MapClaims{"aud": "not.example.com"}, Expected: false, Required: true, Comparison: "example.com"},
+		{Name: "Empty String Aud without match required", MapClaims: MapClaims{"aud": ""}, Expected: false, Required: true, Comparison: "example.com"},
+		{Name: "[]String Aud without match required", MapClaims: MapClaims{"aud": []string{"not.example.com", "example.example.com"}}, Expected: false, Required: true, Comparison: "example.com"},
+		{Name: "Empty []String Aud without match required", MapClaims: MapClaims{"aud": []string{""}}, Expected: false, Required: true, Comparison: "example.com"},
+		{Name: "String Aud without match not required", MapClaims: MapClaims{"aud": "not.example.com"}, Expected: false, Required: true, Comparison: "example.com"},
+		{Name: "Empty String Aud without match not required", MapClaims: MapClaims{"aud": ""}, Expected: false, Required: true, Comparison: "example.com"},
+		{Name: "[]String Aud without match not required", MapClaims: MapClaims{"aud": []string{"not.example.com", "example.example.com"}}, Expected: false, Required: true, Comparison: "example.com"},
 
 		// Required = false
-		{ Name: "Empty []String Aud without match required", MapClaims: MapClaims{"aud": []string{""}}, Expected: false, Required: true, Comparison: "example.com"},
+		{Name: "Empty []String Aud without match required", MapClaims: MapClaims{"aud": []string{""}}, Expected: false, Required: true, Comparison: "example.com"},
 
 		// []interface{}
-		{ Name: "Empty []interface{} Aud without match required", MapClaims: MapClaims{"aud": nilListInterface}, Expected: true, Required: false, Comparison: "example.com"},
-		{ Name: "[]interface{} Aud wit match required", MapClaims: MapClaims{"aud": []interface{}{"a", "foo", "example.com"}}, Expected: true, Required: true, Comparison: "example.com"},
-		{ Name: "[]interface{} Aud wit match but invalid types", MapClaims: MapClaims{"aud": []interface{}{"a", 5, "example.com"}}, Expected: false, Required: true, Comparison: "example.com"},
-		{ Name: "[]interface{} Aud int wit match required", MapClaims: MapClaims{"aud": intListInterface}, Expected: false, Required: true, Comparison: "example.com"},
-
+		{Name: "Empty []interface{} Aud without match required", MapClaims: MapClaims{"aud": nilListInterface}, Expected: true, Required: false, Comparison: "example.com"},
+		{Name: "[]interface{} Aud wit match required", MapClaims: MapClaims{"aud": []interface{}{"a", "foo", "example.com"}}, Expected: true, Required: true, Comparison: "example.com"},
+		{Name: "[]interface{} Aud wit match but invalid types", MapClaims: MapClaims{"aud": []interface{}{"a", 5, "example.com"}}, Expected: false, Required: true, Comparison: "example.com"},
+		{Name: "[]interface{} Aud int wit match required", MapClaims: MapClaims{"aud": intListInterface}, Expected: false, Required: true, Comparison: "example.com"},
 
 		// interface{}
-		{ Name: "Empty interface{} Aud without match not required", MapClaims: MapClaims{"aud": nilInterface}, Expected: true, Required: false, Comparison: "example.com"},
-
+		{Name: "Empty interface{} Aud without match not required", MapClaims: MapClaims{"aud": nilInterface}, Expected: true, Required: false, Comparison: "example.com"},
 	}
-
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {

--- a/map_claims_test.go
+++ b/map_claims_test.go
@@ -7,51 +7,54 @@ import (
 func TestVerifyAud(t *testing.T) {
 	var nilInterface interface{}
 	var nilListInterface []interface{}
-	var intListInterface interface{} = []int{1, 2, 3}
-	type test struct {
-		Name       string
-		MapClaims  MapClaims
-		Expected   bool
+	var intListInterface interface{} = []int{1,2,3}
+	type test struct{
+		Name string
+		MapClaims MapClaims
+		Expected bool
 		Comparison string
-		Required   bool
+		Required bool
 	}
 	tests := []test{
 		// Matching Claim in aud
 		// Required = true
-		{Name: "String Aud matching required", MapClaims: MapClaims{"aud": "example.com"}, Expected: true, Required: true, Comparison: "example.com"},
-		{Name: "[]String Aud with match required", MapClaims: MapClaims{"aud": []string{"example.com", "example.example.com"}}, Expected: true, Required: true, Comparison: "example.com"},
+		{ Name: "String Aud matching required", MapClaims: MapClaims{"aud": "example.com"}, Expected: true , Required: true, Comparison: "example.com"},
+		{ Name: "[]String Aud with match required", MapClaims: MapClaims{"aud": []string{"example.com", "example.example.com"}}, Expected: true, Required: true, Comparison: "example.com"},
 
 		// Required = false
-		{Name: "String Aud with match not required", MapClaims: MapClaims{"aud": "example.com"}, Expected: true, Required: false, Comparison: "example.com"},
-		{Name: "Empty String Aud with match not required", MapClaims: MapClaims{}, Expected: true, Required: false, Comparison: "example.com"},
-		{Name: "Empty String Aud with match not required", MapClaims: MapClaims{"aud": ""}, Expected: true, Required: false, Comparison: "example.com"},
-		{Name: "Nil String Aud with match not required", MapClaims: MapClaims{"aud": nil}, Expected: true, Required: false, Comparison: "example.com"},
+		{ Name: "String Aud with match not required", MapClaims: MapClaims{"aud": "example.com"}, Expected: true , Required: false, Comparison: "example.com"},
+		{ Name: "Empty String Aud with match not required", MapClaims: MapClaims{}, Expected: true , Required: false, Comparison: "example.com"},
+		{ Name: "Empty String Aud with match not required", MapClaims: MapClaims{"aud": ""}, Expected: true , Required: false, Comparison: "example.com"},
+		{ Name: "Nil String Aud with match not required", MapClaims: MapClaims{"aud": nil}, Expected: true , Required: false, Comparison: "example.com"},
 
-		{Name: "[]String Aud with match not required", MapClaims: MapClaims{"aud": []string{"example.com", "example.example.com"}}, Expected: true, Required: false, Comparison: "example.com"},
-		{Name: "Empty []String Aud with match not required", MapClaims: MapClaims{"aud": []string{}}, Expected: true, Required: false, Comparison: "example.com"},
+		{ Name: "[]String Aud with match not required", MapClaims: MapClaims{"aud": []string{"example.com", "example.example.com"}}, Expected: true, Required: false, Comparison: "example.com"},
+		{ Name: "Empty []String Aud with match not required", MapClaims: MapClaims{"aud": []string{}}, Expected: true, Required: false, Comparison: "example.com"},
 
 		// Non-Matching Claim in aud
 		// Required = true
-		{Name: "String Aud without match required", MapClaims: MapClaims{"aud": "not.example.com"}, Expected: false, Required: true, Comparison: "example.com"},
-		{Name: "Empty String Aud without match required", MapClaims: MapClaims{"aud": ""}, Expected: false, Required: true, Comparison: "example.com"},
-		{Name: "[]String Aud without match required", MapClaims: MapClaims{"aud": []string{"not.example.com", "example.example.com"}}, Expected: false, Required: true, Comparison: "example.com"},
-		{Name: "Empty []String Aud without match required", MapClaims: MapClaims{"aud": []string{""}}, Expected: false, Required: true, Comparison: "example.com"},
-		{Name: "String Aud without match not required", MapClaims: MapClaims{"aud": "not.example.com"}, Expected: false, Required: true, Comparison: "example.com"},
-		{Name: "Empty String Aud without match not required", MapClaims: MapClaims{"aud": ""}, Expected: false, Required: true, Comparison: "example.com"},
-		{Name: "[]String Aud without match not required", MapClaims: MapClaims{"aud": []string{"not.example.com", "example.example.com"}}, Expected: false, Required: true, Comparison: "example.com"},
+		{ Name: "String Aud without match required", MapClaims: MapClaims{"aud": "not.example.com"}, Expected: false, Required: true, Comparison: "example.com"},
+		{ Name: "Empty String Aud without match required", MapClaims: MapClaims{"aud": ""}, Expected: false, Required: true, Comparison: "example.com"},
+		{ Name: "[]String Aud without match required", MapClaims: MapClaims{"aud": []string{"not.example.com", "example.example.com"}}, Expected: false, Required: true, Comparison: "example.com"},
+		{ Name: "Empty []String Aud without match required", MapClaims: MapClaims{"aud": []string{""}}, Expected: false, Required: true, Comparison: "example.com"},
+		{ Name: "String Aud without match not required", MapClaims: MapClaims{"aud": "not.example.com"}, Expected: false, Required: true, Comparison: "example.com"},
+		{ Name: "Empty String Aud without match not required", MapClaims: MapClaims{"aud": ""}, Expected: false, Required: true, Comparison: "example.com"},
+		{ Name: "[]String Aud without match not required", MapClaims: MapClaims{"aud": []string{"not.example.com", "example.example.com"}}, Expected: false, Required: true, Comparison: "example.com"},
 
 		// Required = false
-		{Name: "Empty []String Aud without match required", MapClaims: MapClaims{"aud": []string{""}}, Expected: false, Required: true, Comparison: "example.com"},
+		{ Name: "Empty []String Aud without match required", MapClaims: MapClaims{"aud": []string{""}}, Expected: false, Required: true, Comparison: "example.com"},
 
 		// []interface{}
-		{Name: "Empty []interface{} Aud without match required", MapClaims: MapClaims{"aud": nilListInterface}, Expected: true, Required: false, Comparison: "example.com"},
-		{Name: "[]interface{} Aud wit match required", MapClaims: MapClaims{"aud": []interface{}{"a", "foo", "example.com"}}, Expected: true, Required: true, Comparison: "example.com"},
-		{Name: "[]interface{} Aud wit match but invalid types", MapClaims: MapClaims{"aud": []interface{}{"a", 5, "example.com"}}, Expected: false, Required: true, Comparison: "example.com"},
-		{Name: "[]interface{} Aud int wit match required", MapClaims: MapClaims{"aud": intListInterface}, Expected: false, Required: true, Comparison: "example.com"},
+		{ Name: "Empty []interface{} Aud without match required", MapClaims: MapClaims{"aud": nilListInterface}, Expected: true, Required: false, Comparison: "example.com"},
+		{ Name: "[]interface{} Aud wit match required", MapClaims: MapClaims{"aud": []interface{}{"a", "foo", "example.com"}}, Expected: true, Required: true, Comparison: "example.com"},
+		{ Name: "[]interface{} Aud wit match but invalid types", MapClaims: MapClaims{"aud": []interface{}{"a", 5, "example.com"}}, Expected: false, Required: true, Comparison: "example.com"},
+		{ Name: "[]interface{} Aud int wit match required", MapClaims: MapClaims{"aud": intListInterface}, Expected: false, Required: true, Comparison: "example.com"},
+
 
 		// interface{}
-		{Name: "Empty interface{} Aud without match not required", MapClaims: MapClaims{"aud": nilInterface}, Expected: true, Required: false, Comparison: "example.com"},
+		{ Name: "Empty interface{} Aud without match not required", MapClaims: MapClaims{"aud": nilInterface}, Expected: true, Required: false, Comparison: "example.com"},
+
 	}
+
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {

--- a/none.go
+++ b/none.go
@@ -9,13 +9,13 @@ const UnsafeAllowNoneSignatureType unsafeNoneMagicConstant = "none signing metho
 
 var (
 	// The none signing method is required by the spec, but you should probably never use it.
-	SigningMethodNone                = NewSigningMethodNone()
+	SigningMethodNone                = newSigningMethodNone()
 	NoneSignatureTypeDisallowedError = NewValidationError("'none' signature type is not allowed", ValidationErrorSignatureInvalid)
 )
 
-// NewSigningMethodNone creates a new SigningMethodNone struct and
+// newSigningMethodNone creates a new SigningMethodNone struct and
 // registers it as a signing method.
-func NewSigningMethodNone() *signingMethodNone {
+func newSigningMethodNone() *signingMethodNone {
 	m := &signingMethodNone{}
 	Register(m)
 	return m

--- a/none.go
+++ b/none.go
@@ -14,7 +14,7 @@ var (
 )
 
 // NewSigningMethodNone creates a new SigningMethodNone struct and
-// registers it with RegisterSigningMethod.
+// registers it as a signing method.
 func NewSigningMethodNone() *signingMethodNone {
 	m := &signingMethodNone{}
 	Register(m)

--- a/none.go
+++ b/none.go
@@ -1,23 +1,24 @@
 package jwt
 
-// SigningMethodNone implements the none signing method.  This is required by the spec
-// but you probably should never use it.
-var SigningMethodNone *signingMethodNone
+type (
+	signingMethodNone       struct{}
+	unsafeNoneMagicConstant string
+)
 
 const UnsafeAllowNoneSignatureType unsafeNoneMagicConstant = "none signing method allowed"
 
-var NoneSignatureTypeDisallowedError error
-
-type signingMethodNone struct{}
-type unsafeNoneMagicConstant string
-
-func init() {
-	SigningMethodNone = &signingMethodNone{}
+var (
+	// The none signing method is required by the spec, but you should probably never use it.
+	SigningMethodNone                = NewSigningMethodNone()
 	NoneSignatureTypeDisallowedError = NewValidationError("'none' signature type is not allowed", ValidationErrorSignatureInvalid)
+)
 
-	RegisterSigningMethod(SigningMethodNone.Alg(), func() SigningMethod {
-		return SigningMethodNone
-	})
+// NewSigningMethodNone creates a new SigningMethodNone struct and
+// registers it with RegisterSigningMethod.
+func NewSigningMethodNone() *signingMethodNone {
+	m := &signingMethodNone{}
+	Register(m)
+	return m
 }
 
 func (m *signingMethodNone) Alg() string {

--- a/rsa.go
+++ b/rsa.go
@@ -15,14 +15,14 @@ type SigningMethodRSA struct {
 
 // Specific instances for RS256 and company
 var (
-	SigningMethodRS256 = NewSigningMethodRSA("RS256", crypto.SHA256)
-	SigningMethodRS384 = NewSigningMethodRSA("RS384", crypto.SHA384)
-	SigningMethodRS512 = NewSigningMethodRSA("RS512", crypto.SHA512)
+	SigningMethodRS256 = newSigningMethodRSA("RS256", crypto.SHA256)
+	SigningMethodRS384 = newSigningMethodRSA("RS384", crypto.SHA384)
+	SigningMethodRS512 = newSigningMethodRSA("RS512", crypto.SHA512)
 )
 
-// NewSigningMethodRSA creates a new SigningMethodRSA struct and
+// newSigningMethodRSA creates a new SigningMethodRSA struct and
 // registers it as a signing method.
-func NewSigningMethodRSA(name string, hash crypto.Hash) *SigningMethodRSA {
+func newSigningMethodRSA(name string, hash crypto.Hash) *SigningMethodRSA {
 	m := &SigningMethodRSA{name, hash}
 	Register(m)
 	return m

--- a/rsa.go
+++ b/rsa.go
@@ -21,7 +21,7 @@ var (
 )
 
 // NewSigningMethodRSA creates a new SigningMethodRSA struct and
-// registers it with RegisterSigningMethod.
+// registers it as a signing method.
 func NewSigningMethodRSA(name string, hash crypto.Hash) *SigningMethodRSA {
 	m := &SigningMethodRSA{name, hash}
 	Register(m)

--- a/rsa.go
+++ b/rsa.go
@@ -15,29 +15,17 @@ type SigningMethodRSA struct {
 
 // Specific instances for RS256 and company
 var (
-	SigningMethodRS256 *SigningMethodRSA
-	SigningMethodRS384 *SigningMethodRSA
-	SigningMethodRS512 *SigningMethodRSA
+	SigningMethodRS256 = NewSigningMethodRSA("RS256", crypto.SHA256)
+	SigningMethodRS384 = NewSigningMethodRSA("RS384", crypto.SHA384)
+	SigningMethodRS512 = NewSigningMethodRSA("RS512", crypto.SHA512)
 )
 
-func init() {
-	// RS256
-	SigningMethodRS256 = &SigningMethodRSA{"RS256", crypto.SHA256}
-	RegisterSigningMethod(SigningMethodRS256.Alg(), func() SigningMethod {
-		return SigningMethodRS256
-	})
-
-	// RS384
-	SigningMethodRS384 = &SigningMethodRSA{"RS384", crypto.SHA384}
-	RegisterSigningMethod(SigningMethodRS384.Alg(), func() SigningMethod {
-		return SigningMethodRS384
-	})
-
-	// RS512
-	SigningMethodRS512 = &SigningMethodRSA{"RS512", crypto.SHA512}
-	RegisterSigningMethod(SigningMethodRS512.Alg(), func() SigningMethod {
-		return SigningMethodRS512
-	})
+// NewSigningMethodRSA creates a new SigningMethodRSA struct and
+// registers it with RegisterSigningMethod.
+func NewSigningMethodRSA(name string, hash crypto.Hash) *SigningMethodRSA {
+	m := &SigningMethodRSA{name, hash}
+	Register(m)
+	return m
 }
 
 func (m *SigningMethodRSA) Alg() string {

--- a/rsa_pss.go
+++ b/rsa_pss.go
@@ -23,7 +23,7 @@ type SigningMethodRSAPSS struct {
 var (
 
 	// PS256
-	SigningMethodPS256 = NewSigningMethodRSAPSS(
+	SigningMethodPS256 = newSigningMethodRSAPSS(
 		&SigningMethodRSA{
 			Name: "PS256",
 			Hash: crypto.SHA256,
@@ -37,7 +37,7 @@ var (
 	)
 
 	// PS384
-	SigningMethodPS384 = NewSigningMethodRSAPSS(
+	SigningMethodPS384 = newSigningMethodRSAPSS(
 		&SigningMethodRSA{
 			Name: "PS384",
 			Hash: crypto.SHA384,
@@ -51,7 +51,7 @@ var (
 	)
 
 	// PS512
-	SigningMethodPS512 = NewSigningMethodRSAPSS(
+	SigningMethodPS512 = newSigningMethodRSAPSS(
 		&SigningMethodRSA{
 			Name: "PS512",
 			Hash: crypto.SHA512,
@@ -65,9 +65,9 @@ var (
 	)
 )
 
-// NewSigningMethodRSAPSS creates a new SigningMethodRSAPSS struct and
+// newSigningMethodRSAPSS creates a new SigningMethodRSAPSS struct and
 // registers it as a signing method.
-func NewSigningMethodRSAPSS(smRSA *SigningMethodRSA, options *rsa.PSSOptions, verifyOptions ...*rsa.PSSOptions) *SigningMethodRSAPSS {
+func newSigningMethodRSAPSS(smRSA *SigningMethodRSA, options *rsa.PSSOptions, verifyOptions ...*rsa.PSSOptions) *SigningMethodRSAPSS {
 	m := &SigningMethodRSAPSS{
 		SigningMethodRSA: smRSA,
 		Options:          options,

--- a/rsa_pss.go
+++ b/rsa_pss.go
@@ -21,62 +21,65 @@ type SigningMethodRSAPSS struct {
 
 // Specific instances for RS/PS and company.
 var (
-	SigningMethodPS256 *SigningMethodRSAPSS
-	SigningMethodPS384 *SigningMethodRSAPSS
-	SigningMethodPS512 *SigningMethodRSAPSS
-)
 
-func init() {
 	// PS256
-	SigningMethodPS256 = &SigningMethodRSAPSS{
-		SigningMethodRSA: &SigningMethodRSA{
+	SigningMethodPS256 = NewSigningMethodRSAPSS(
+		&SigningMethodRSA{
 			Name: "PS256",
 			Hash: crypto.SHA256,
 		},
-		Options: &rsa.PSSOptions{
+		&rsa.PSSOptions{
 			SaltLength: rsa.PSSSaltLengthEqualsHash,
 		},
-		VerifyOptions: &rsa.PSSOptions{
+		&rsa.PSSOptions{
 			SaltLength: rsa.PSSSaltLengthAuto,
 		},
-	}
-	RegisterSigningMethod(SigningMethodPS256.Alg(), func() SigningMethod {
-		return SigningMethodPS256
-	})
+	)
 
 	// PS384
-	SigningMethodPS384 = &SigningMethodRSAPSS{
-		SigningMethodRSA: &SigningMethodRSA{
+	SigningMethodPS384 = NewSigningMethodRSAPSS(
+		&SigningMethodRSA{
 			Name: "PS384",
 			Hash: crypto.SHA384,
 		},
-		Options: &rsa.PSSOptions{
+		&rsa.PSSOptions{
 			SaltLength: rsa.PSSSaltLengthEqualsHash,
 		},
-		VerifyOptions: &rsa.PSSOptions{
+		&rsa.PSSOptions{
 			SaltLength: rsa.PSSSaltLengthAuto,
 		},
-	}
-	RegisterSigningMethod(SigningMethodPS384.Alg(), func() SigningMethod {
-		return SigningMethodPS384
-	})
+	)
 
 	// PS512
-	SigningMethodPS512 = &SigningMethodRSAPSS{
-		SigningMethodRSA: &SigningMethodRSA{
+	SigningMethodPS512 = NewSigningMethodRSAPSS(
+		&SigningMethodRSA{
 			Name: "PS512",
 			Hash: crypto.SHA512,
 		},
-		Options: &rsa.PSSOptions{
+		&rsa.PSSOptions{
 			SaltLength: rsa.PSSSaltLengthEqualsHash,
 		},
-		VerifyOptions: &rsa.PSSOptions{
+		&rsa.PSSOptions{
 			SaltLength: rsa.PSSSaltLengthAuto,
 		},
+	)
+)
+
+// NewSigningMethodRSAPSS creates a new SigningMethodRSAPSS struct and
+// registers it with RegisterSigningMethod.
+func NewSigningMethodRSAPSS(smRSA *SigningMethodRSA, options *rsa.PSSOptions, verifyOptions ...*rsa.PSSOptions) *SigningMethodRSAPSS {
+	m := &SigningMethodRSAPSS{
+		SigningMethodRSA: smRSA,
+		Options:          options,
+		VerifyOptions:    &rsa.PSSOptions{},
 	}
-	RegisterSigningMethod(SigningMethodPS512.Alg(), func() SigningMethod {
-		return SigningMethodPS512
-	})
+	// If an additional *rsa.PSSOptions struct is given, use that for the VerifyOptions field.
+	// VerifyOptions is optional.
+	if len(verifyOptions) == 1 {
+		m.VerifyOptions = verifyOptions[0]
+	}
+	Register(m)
+	return m
 }
 
 // Verify implements token verification for the SigningMethod.

--- a/rsa_pss.go
+++ b/rsa_pss.go
@@ -66,7 +66,7 @@ var (
 )
 
 // NewSigningMethodRSAPSS creates a new SigningMethodRSAPSS struct and
-// registers it with RegisterSigningMethod.
+// registers it as a signing method.
 func NewSigningMethodRSAPSS(smRSA *SigningMethodRSA, options *rsa.PSSOptions, verifyOptions ...*rsa.PSSOptions) *SigningMethodRSAPSS {
 	m := &SigningMethodRSAPSS{
 		SigningMethodRSA: smRSA,

--- a/signing_method.go
+++ b/signing_method.go
@@ -14,7 +14,7 @@ type SigningMethod interface {
 	Alg() string                                                   // returns the alg identifier for this method (example: 'HS256')
 }
 
-// Register create a new function that returns the given
+// Register internally creates a new function that returns the given
 // SigningMethod. The function will be stored as a value in a thread safe map,
 // where the algorithm name is the key.
 func Register(m SigningMethod) {

--- a/signing_method.go
+++ b/signing_method.go
@@ -25,6 +25,7 @@ func Register(m SigningMethod) {
 
 // RegisterSigningMethod will use the given algorithm name as the key
 // and store the given function as the value.
+// Deprecated: use the Register function instead
 func RegisterSigningMethod(alg string, f func() SigningMethod) {
 	signingMethodLock.Lock()
 	defer signingMethodLock.Unlock()


### PR DESCRIPTION
* Add new functions for creating SigningMethod structs, like `NewSigningMethodECDSA`.
* Use `var` instead of `init` functions.
* Let RegisterSigningMethod take a `SigningMethod` type, and let `RegisterSigningMethodFunc` take an algorithm name and a function that returns a SigningMethod.
* The suggested changes adds 122 lines and removes 147 lines.
* All tests pass.