### PR TITLE
jwt: Return better error messages on malformed tokens

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -107,10 +107,10 @@ func (p *Parser) ParseUnverified(tokenString string, claims Claims) (token *Toke
 		if strings.HasPrefix(strings.ToLower(tokenString), "bearer ") {
 			return token, parts, NewValidationError("tokenstring should not contain 'bearer '", ValidationErrorMalformed)
 		}
-		return token, parts, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
+		return token, parts, &ValidationError{Inner: fmt.Errorf("malformed token header: %w", err), Errors: ValidationErrorMalformed}
 	}
 	if err = json.Unmarshal(headerBytes, &token.Header); err != nil {
-		return token, parts, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
+		return token, parts, &ValidationError{Inner: fmt.Errorf("malformed token header: %w", err), Errors: ValidationErrorMalformed}
 	}
 
 	// parse Claims
@@ -118,7 +118,7 @@ func (p *Parser) ParseUnverified(tokenString string, claims Claims) (token *Toke
 	token.Claims = claims
 
 	if claimBytes, err = DecodeSegment(parts[1]); err != nil {
-		return token, parts, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
+		return token, parts, &ValidationError{Inner: fmt.Errorf("malformed token claims: %w", err), Errors: ValidationErrorMalformed}
 	}
 	dec := json.NewDecoder(bytes.NewBuffer(claimBytes))
 	if p.UseJSONNumber {
@@ -132,7 +132,7 @@ func (p *Parser) ParseUnverified(tokenString string, claims Claims) (token *Toke
 	}
 	// Handle decode error
 	if err != nil {
-		return token, parts, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
+		return token, parts, &ValidationError{Inner: fmt.Errorf("malformed token payload: %w", err), Errors: ValidationErrorMalformed}
 	}
 
 	// Lookup signature method

--- a/parser_test.go
+++ b/parser_test.go
@@ -287,6 +287,21 @@ func TestParser_ParseUnverified(t *testing.T) {
 	}
 }
 
+func Test_ParseWithInvalidJSONPayload(t *testing.T) {
+	tokenString := "eyJhbGciOiJSUzI1NiIsInppcCI6IkRFRiJ9.eNqqVkqtKFCyMjQ1s7Q0sbA0MtFRyk3NTUot8kxRslIKLbZQggn4JeamAoUcfRz99HxcXRWeze172tr4bFq7Ui0AAAD__w.jBXD4LT4aq4oXTgDoPkiV6n4QdSZPZI1Z4J8MWQC42aHK0oXwcovEU06dVbtB81TF-2byuu0-qi8J0GUttODT67k6gCl6DV_iuCOV7gczwTcvKslotUvXzoJ2wa0QuujnjxLEE50r0p6k0tsv_9OIFSUZzDksJFYNPlJH2eFG55DROx4TsOz98az37SujZi9GGbTc9SLgzFHPrHMrovRZ5qLC_w4JrdtsLzBBI11OQJgRYwV8fQf4O8IsMkHtetjkN7dKgUkJtRarNWOk76rpTPppLypiLU4_J0-wrElLMh1TzUVZW6Fz2cDHDDBACJgMmKQ2pOFEDK_vYZN74dLCF5GiTZV6DbXhNxO7lqT7JUN4a3p2z96G7WNRjblf2qZeuYdQvkIsiK-rCbSIE836XeY5gaBgkOzuEvzl_tMrpRmb5Oox1ibOfVT2KBh9Lvqsb1XbQjCio2CLE2ViCLqoe0AaRqlUyrk3n8BIG-r0IW4dcw96CEryEMIjsjVp9mtPXamJzf391kt8Rf3iRBqwv3zP7Plg1ResXbmsFUgOflAUPcYmfLug4W3W52ntcUlTHAKXrNfaJL9QQiYAaDukG-ZHDytsOWTuuXw7lVxjt-XYi1VbRAIjh1aIYSELEmEpE4Ny74htQtywYXMQNfJpB0nNn8IiWakgcYYMJ0TmKM"
+
+	_, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		return nil, nil
+	})
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err.Error() != "malformed token payload: invalid character 'x' looking for beginning of value" {
+		t.Errorf("unexpected error \"%s\"", err.Error())
+	}
+}
+
 func BenchmarkParseUnverified(b *testing.B) {
 	privateKey := test.LoadRSAPrivateKeyFromDisk("test/sample_key")
 


### PR DESCRIPTION
Fixes #75, as the jwt.io debugger also considers this payload invalid JSON and is validated as expected