### PR TITLE
When exp indicates the present, make it invalid.

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -116,7 +116,7 @@ func verifyExp(exp int64, now int64, required bool) bool {
 	if exp == 0 {
 		return !required
 	}
-	return now <= exp
+	return now < exp
 }
 
 func verifyIat(iat int64, now int64, required bool) bool {

--- a/map_claims_test.go
+++ b/map_claims_test.go
@@ -2,6 +2,7 @@ package jwt
 
 import (
 	"testing"
+	"time"
 )
 
 func TestVerifyAud(t *testing.T) {
@@ -96,6 +97,29 @@ func TestMapclaimsVerifyExpiresAtInvalidTypeString(t *testing.T) {
 	want := false
 	got := mapClaims.VerifyExpiresAt(0, false)
 
+	if want != got {
+		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
+	}
+}
+
+func TestMapclaimsVerifyExpiresAtExpire(t *testing.T) {
+	exp := time.Now().Unix()
+	mapClaims := MapClaims{
+		"exp": float64(exp),
+	}
+	want := false
+	got := mapClaims.VerifyExpiresAt(exp, true)
+	if want != got {
+		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
+	}
+
+	got = mapClaims.VerifyExpiresAt(exp + 1, true)
+	if want != got {
+		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
+	}
+
+	want = true
+	got = mapClaims.VerifyExpiresAt(exp - 1, true)
 	if want != got {
 		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
 	}

--- a/map_claims_test.go
+++ b/map_claims_test.go
@@ -99,7 +99,7 @@ func TestMapclaimsVerifyExpiresAtInvalidTypeString(t *testing.T) {
 	}
 }
 
-func TestMapclaimsVerifyExpiresAtExpire(t *testing.T) {
+func TestMapClaimsVerifyExpiresAtExpire(t *testing.T) {
 	exp := time.Now().Unix()
 	mapClaims := MapClaims{
 		"exp": float64(exp),


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4

>  The "exp" (expiration time) claim identifies the expiration time on
   or after which the JWT MUST NOT be accepted for processing.

it is written on the reference.
So, it seems invalid when exp indicates the present. Isn't it right?