### PR TITLE
Accept `crypto.Signer` that contains a `ed25519.PublicKey` in ed25519

### DIFF
--- a/ed25519.go
+++ b/ed25519.go
@@ -76,7 +76,7 @@ func (m *SigningMethodEd25519) Sign(signingString string, key interface{}) (stri
 	}
 
 	// Sign the string and return the encoded result
-	// ed25519 does not using any hash algorithm, which is what crypto.Hash(0) stands for
+	// ed25519 performs a two-pass hash as part of its algorithm. Therefore, we need to pass a non-prehashed message into the Sign function, as indicated by crypto.Hash(0)
 	sig, err := ed25519Key.Sign(rand.Reader, []byte(signingString), crypto.Hash(0))
 	if err != nil {
 		return "", err

--- a/ed25519.go
+++ b/ed25519.go
@@ -71,6 +71,10 @@ func (m *SigningMethodEd25519) Sign(signingString string, key interface{}) (stri
 		return "", ErrInvalidKeyType
 	}
 
+	if _, ok := ed25519Key.Public().(ed25519.PublicKey); !ok {
+		return "", ErrInvalidKey
+	}
+
 	// Sign the string and return the encoded result
 	sig, err := ed25519Key.Sign(rand.Reader, []byte(signingString), crypto.Hash(0))
 	if err != nil {

--- a/ed25519.go
+++ b/ed25519.go
@@ -76,6 +76,7 @@ func (m *SigningMethodEd25519) Sign(signingString string, key interface{}) (stri
 	}
 
 	// Sign the string and return the encoded result
+	// ed25519 does not using any hash algorithm, which is what crypto.Hash(0) stands for
 	sig, err := ed25519Key.Sign(rand.Reader, []byte(signingString), crypto.Hash(0))
 	if err != nil {
 		return "", err

--- a/ed25519.go
+++ b/ed25519.go
@@ -3,7 +3,9 @@ package jwt
 import (
 	"errors"
 
+	"crypto"
 	"crypto/ed25519"
+	"crypto/rand"
 )
 
 var (
@@ -62,20 +64,17 @@ func (m *SigningMethodEd25519) Verify(signingString, signature string, key inter
 // Sign implements token signing for the SigningMethod.
 // For this signing method, key must be an ed25519.PrivateKey
 func (m *SigningMethodEd25519) Sign(signingString string, key interface{}) (string, error) {
-	var ed25519Key ed25519.PrivateKey
+	var ed25519Key crypto.Signer
 	var ok bool
 
-	if ed25519Key, ok = key.(ed25519.PrivateKey); !ok {
+	if ed25519Key, ok = key.(crypto.Signer); !ok {
 		return "", ErrInvalidKeyType
 	}
 
-	// ed25519.Sign panics if private key not equal to ed25519.PrivateKeySize
-	// this allows to avoid recover usage
-	if len(ed25519Key) != ed25519.PrivateKeySize {
-		return "", ErrInvalidKey
-	}
-
 	// Sign the string and return the encoded result
-	sig := ed25519.Sign(ed25519Key, []byte(signingString))
+	sig, err := ed25519Key.Sign(rand.Reader, []byte(signingString), crypto.Hash(0))
+	if err != nil {
+		return "", err
+	}
 	return EncodeSegment(sig), nil
 }


### PR DESCRIPTION
in order to allow usage of other ed25519 providers than crypto/ed25519

For example in my case I use a HSM (YubiHSM2), which means the private key is not visible to the go code (can't check its len, etc), however it is indeed a ed25519 key and the object provides the Sign() method

The HSM lib: https://github.com/KarpelesLab/hsm