### PR TITLE
Refactors errors to use go 1.13 style

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -2,8 +2,9 @@ package jwt
 
 import (
 	"crypto/subtle"
-	"fmt"
 	"time"
+
+	"github.com/hashicorp/go-multierror"
 )
 
 // Claims must just have a Valid method that determines
@@ -49,32 +50,32 @@ type RegisteredClaims struct {
 // As well, if any of the above claims are not in the token, it will still
 // be considered a valid claim.
 func (c RegisteredClaims) Valid() error {
-	vErr := new(ValidationError)
-	now := TimeFunc()
+	var result *multierror.Error
+	result.ErrorFormat = ValidationErrorFormat
 
+	now := TimeFunc()
 	// The claims below are optional, by default, so if they are set to the
 	// default value in Go, let's not fail the verification for them.
 	if !c.VerifyExpiresAt(now, false) {
-		delta := now.Sub(c.ExpiresAt.Time)
-		vErr.Inner = fmt.Errorf("token is expired by %v", delta)
-		vErr.Errors |= ValidationErrorExpired
+		result = multierror.Append(result, &ExpiredError{
+			ExpiredAt:   c.ExpiresAt.Time,
+			AttemptedAt: now,
+		})
 	}
-
 	if !c.VerifyIssuedAt(now, false) {
-		vErr.Inner = fmt.Errorf("token used before issued")
-		vErr.Errors |= ValidationErrorIssuedAt
+		result = multierror.Append(result, &UsedBeforeIssuedError{
+			IssuedAt:    c.IssuedAt.Time,
+			AttemptedAt: now,
+		})
 	}
-
 	if !c.VerifyNotBefore(now, false) {
-		vErr.Inner = fmt.Errorf("token is not valid yet")
-		vErr.Errors |= ValidationErrorNotValidYet
+		result = multierror.Append(result, &NotYetValidError{
+			ValidAt:     c.NotBefore.Time,
+			AttemptedAt: now,
+		})
 	}
 
-	if vErr.valid() {
-		return nil
-	}
-
-	return vErr
+	return result.ErrorOrNil()
 }
 
 // VerifyAudience compares the aud claim against cmp.
@@ -136,32 +137,33 @@ type StandardClaims struct {
 // As well, if any of the above claims are not in the token, it will still
 // be considered a valid claim.
 func (c StandardClaims) Valid() error {
-	vErr := new(ValidationError)
-	now := TimeFunc().Unix()
+	var result *multierror.Error
+	result.ErrorFormat = ValidationErrorFormat
 
+	now := TimeFunc()
+	nowUnix := now.Unix()
 	// The claims below are optional, by default, so if they are set to the
 	// default value in Go, let's not fail the verification for them.
-	if !c.VerifyExpiresAt(now, false) {
-		delta := time.Unix(now, 0).Sub(time.Unix(c.ExpiresAt, 0))
-		vErr.Inner = fmt.Errorf("token is expired by %v", delta)
-		vErr.Errors |= ValidationErrorExpired
-	}
 
-	if !c.VerifyIssuedAt(now, false) {
-		vErr.Inner = fmt.Errorf("token used before issued")
-		vErr.Errors |= ValidationErrorIssuedAt
+	if !c.VerifyExpiresAt(nowUnix, false) {
+		result = multierror.Append(result, &ExpiredError{
+			ExpiredAt:   time.Unix(c.ExpiresAt, 0),
+			AttemptedAt: now,
+		})
 	}
-
-	if !c.VerifyNotBefore(now, false) {
-		vErr.Inner = fmt.Errorf("token is not valid yet")
-		vErr.Errors |= ValidationErrorNotValidYet
+	if !c.VerifyIssuedAt(nowUnix, false) {
+		result = multierror.Append(result, &UsedBeforeIssuedError{
+			IssuedAt:    time.Unix(c.IssuedAt, 0),
+			AttemptedAt: now,
+		})
 	}
-
-	if vErr.valid() {
-		return nil
+	if !c.VerifyNotBefore(nowUnix, false) {
+		result = multierror.Append(result, &NotYetValidError{
+			ValidAt:     time.Unix(c.NotBefore, 0),
+			AttemptedAt: now,
+		})
 	}
-
-	return vErr
+	return result.ErrorOrNil()
 }
 
 // VerifyAudience compares the aud claim against cmp.

--- a/errors.go
+++ b/errors.go
@@ -2,58 +2,167 @@ package jwt
 
 import (
 	"errors"
+	"fmt"
+	"strings"
+	"time"
 )
+
+var ValidationErrorFormat = func(errs []error) string {
+
+	str := "jwt: errors occurred validating the claims"
+	for _, err := range errs {
+		errstr := strings.TrimPrefix(err.Error(), "jwt: ")
+		if len(errstr) > 0 {
+			str = str + "\n\t" + errstr
+		}
+	}
+	return str
+}
 
 // Error constants
 var (
-	ErrInvalidKey      = errors.New("key is invalid")
-	ErrInvalidKeyType  = errors.New("key is of invalid type")
-	ErrHashUnavailable = errors.New("the requested hash function is unavailable")
+	ErrMalformedToken              = errors.New("jwt: token is malformed")
+	ErrTokenContainsBearer         = errors.New(`token may not contain "bearer"`)
+	ErrInvalidSigningMethod        = errors.New("jwt: invalid signing method")
+	ErrUnregisteredSigningMethod   = errors.New("jwt: signing method not registered")
+	ErrInvalidKey                  = errors.New("jwt: key is invalid")
+	ErrInvalidKeyType              = errors.New("jwt: key is of invalid type")
+	ErrHashUnavailable             = errors.New("jwt: the requested hash function is unavailable")
+	ErrTokenNotYetValid            = errors.New("jwt: the token is not yet valid")
+	ErrTokenExpired                = errors.New("jwt: the token is expired")
+	ErrTokenUsedBeforeIssued       = errors.New("jwt: the token was used before issued")
+	ErrNoneSignatureTypeDisallowed = errors.New(`jwt: "none" signature type is not allowed`)
+	ErrMissingKeyFunc              = errors.New("jwt: KeyFunc not provided")
 )
+
+type MalformedTokenError string
+
+func (err MalformedTokenError) Error() string {
+	str := ErrMalformedToken.Error()
+	if len(err) > 0 {
+		str = str + "\n\t" + string(err)
+	}
+	return str
+}
+
+func (err MalformedTokenError) Unwrap() error {
+	return ErrMalformedToken
+}
+
+type UnregisteredSigningMethodError struct {
+	Alg string
+}
+
+func (err *UnregisteredSigningMethodError) Error() string {
+	return `jwt: signing method "` + err.Alg + `" is not registered`
+}
+
+func (err *UnregisteredSigningMethodError) Unwrap() error {
+	return ErrUnregisteredSigningMethod
+}
+
+type InvalidSigningMethodError struct {
+	Alg string
+}
+
+func (err *InvalidSigningMethodError) Error() string {
+	return `jwt: signing method "` + err.Alg + `" is invalid`
+}
+
+func (err *InvalidSigningMethodError) Unwrap() error {
+	return ErrInvalidSigningMethod
+}
+
+type NotYetValidError struct {
+	ValidAt     time.Time
+	AttemptedAt time.Time
+}
+
+func (err *NotYetValidError) Delta() time.Duration {
+	return err.AttemptedAt.Sub(err.ValidAt)
+}
+func (err *NotYetValidError) Error() string {
+	return fmt.Sprintf("token is not valid for another %v", err.Delta)
+}
+func (err *NotYetValidError) Unwrap() error {
+	return ErrTokenNotYetValid
+}
+
+type UsedBeforeIssuedError struct {
+	IssuedAt    time.Time
+	AttemptedAt time.Time
+}
+
+func (err *UsedBeforeIssuedError) Delta() time.Duration {
+	return err.IssuedAt.Sub(err.AttemptedAt)
+}
+
+func (err *UsedBeforeIssuedError) Error() string {
+	return fmt.Sprintf("token is not valid for another %v", err.Delta)
+}
+func (err *UsedBeforeIssuedError) Unwrap() error {
+	return ErrTokenUsedBeforeIssued
+}
+
+type ExpiredError struct {
+	ExpiredAt   time.Time
+	AttemptedAt time.Time
+}
+
+func (err *ExpiredError) Delta() time.Duration {
+	return err.ExpiredAt.Sub(err.AttemptedAt)
+}
+
+func (err *ExpiredError) Error() string {
+	return fmt.Sprintf("token is expired by %v", err.Delta)
+}
+func (err *ExpiredError) Unwrap() error {
+	return ErrTokenNotYetValid
+}
 
 // The errors that might occur when parsing and validating a token
 const (
-	ValidationErrorMalformed        uint32 = 1 << iota // Token is malformed
-	ValidationErrorUnverifiable                        // Token could not be verified because of signing problems
-	ValidationErrorSignatureInvalid                    // Signature validation failed
+// ValidationErrorMalformed        uint32 = 1 << iota // Token is malformed
+// ValidationErrorUnverifiable                        // Token could not be verified because of signing problems
+// ValidationErrorSignatureInvalid                    // Signature validation failed
 
-	// Standard Claim validation errors
-	ValidationErrorAudience      // AUD validation failed
-	ValidationErrorExpired       // EXP validation failed
-	ValidationErrorIssuedAt      // IAT validation failed
-	ValidationErrorIssuer        // ISS validation failed
-	ValidationErrorNotValidYet   // NBF validation failed
-	ValidationErrorId            // JTI validation failed
-	ValidationErrorClaimsInvalid // Generic claims validation error
+// Standard Claim validation errors
+// ValidationErrorAudience      // AUD validation failed
+// ValidationErrorExpired       // EXP validation failed
+// ValidationErrorIssuedAt      // IAT validation failed
+// ValidationErrorIssuer        // ISS validation failed
+// ValidationErrorNotValidYet   // NBF validation failed
+// ValidationErrorId            // JTI validation failed
+// ValidationErrorClaimsInvalid // Generic claims validation error
 )
 
-// NewValidationError is a helper for constructing a ValidationError with a string error message
-func NewValidationError(errorText string, errorFlags uint32) *ValidationError {
-	return &ValidationError{
-		text:   errorText,
-		Errors: errorFlags,
-	}
-}
+// // NewValidationError is a helper for constructing a ValidationError with a string error message
+// func NewValidationError(errorText string, errorFlags uint32) *ValidationError {
+// 	return &ValidationError{
+// 		text:   errorText,
+// 		Errors: errorFlags,
+// 	}
+// }
 
-// ValidationError represents an error from Parse if token is not valid
-type ValidationError struct {
-	Inner  error  // stores the error returned by external dependencies, i.e.: KeyFunc
-	Errors uint32 // bitfield.  see ValidationError... constants
-	text   string // errors that do not have a valid error just have text
-}
+// // ValidationError represents an error from Parse if token is not valid
+// type ValidationError struct {
+// 	Inner  error  // stores the error returned by external dependencies, i.e.: KeyFunc
+// 	Errors uint32 // bitfield.  see ValidationError... constants
+// 	text   string // errors that do not have a valid error just have text
+// }
 
-// Error is the implementation of the err interface.
-func (e ValidationError) Error() string {
-	if e.Inner != nil {
-		return e.Inner.Error()
-	} else if e.text != "" {
-		return e.text
-	} else {
-		return "token is invalid"
-	}
-}
+// // Error is the implementation of the err interface.
+// func (e ValidationError) Error() string {
+// 	if e.Inner != nil {
+// 		return e.Inner.Error()
+// 	} else if e.text != "" {
+// 		return e.text
+// 	} else {
+// 		return "token is invalid"
+// 	}
+// }
 
-// No errors
-func (e *ValidationError) valid() bool {
-	return e.Errors == 0
-}
+// // No errors
+// func (e *ValidationError) valid() bool {
+// 	return e.Errors == 0
+// }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/golang-jwt/jwt/v4
 
 go 1.15
+
+require github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=

--- a/map_claims.go
+++ b/map_claims.go
@@ -2,18 +2,86 @@ package jwt
 
 import (
 	"encoding/json"
-	"errors"
+	"fmt"
 	"time"
-	// "fmt"
+
+	"github.com/hashicorp/go-multierror"
 )
 
 // MapClaims is a claims type that uses the map[string]interface{} for JSON decoding.
 // This is the default claims type if you don't supply one
 type MapClaims map[string]interface{}
 
-// VerifyAudience Compares the aud claim against cmp.
-// If required is false, this method will return true if the value matches or is unset
-func (m MapClaims) VerifyAudience(cmp string, req bool) bool {
+func (m MapClaims) ExpiresAt() *time.Time {
+	exp := m["exp"]
+	switch exp := exp.(type) {
+	case float64:
+		if exp == 0 {
+			return nil
+		}
+		return &newNumericDateFromSeconds(exp).Time
+	case json.Number:
+		v, _ := exp.Float64()
+		if v == 0 {
+			return nil
+		}
+		return &newNumericDateFromSeconds(v).Time
+	default:
+		return nil
+	}
+}
+
+func (m MapClaims) IssuedAt() *time.Time {
+	iat := m["iat"]
+	switch exp := iat.(type) {
+	case float64:
+		if exp == 0 {
+			return nil
+		}
+		return &newNumericDateFromSeconds(exp).Time
+	case json.Number:
+		v, _ := exp.Float64()
+		if v == 0 {
+			return nil
+		}
+		return &newNumericDateFromSeconds(v).Time
+	default:
+		return nil
+	}
+}
+
+// NotBefore returns the *time.Time parsed nbf field of the MapClaims if present
+// or nil otherwise
+func (m MapClaims) NotBefore() *time.Time {
+	v := m["nbf"]
+	switch nbf := v.(type) {
+	case float64:
+		if nbf == 0 {
+			return nil
+		}
+		return &newNumericDateFromSeconds(nbf).Time
+	case json.Number:
+		v, _ := nbf.Float64()
+		if v == 0 {
+			return nil
+		}
+		return &newNumericDateFromSeconds(v).Time
+	default:
+		return nil
+	}
+}
+
+// Issuer returns the iss field of the MapClaims
+func (m MapClaims) Issuer() string {
+	iss := m["iss"]
+	if str, ok := iss.(string); ok {
+		return str
+	}
+	return ""
+}
+
+func (m MapClaims) Audience() ([]string, error) {
+	var err *multierror.Error
 	var aud []string
 	switch v := m["aud"].(type) {
 	case string:
@@ -22,12 +90,22 @@ func (m MapClaims) VerifyAudience(cmp string, req bool) bool {
 		aud = v
 	case []interface{}:
 		for _, a := range v {
-			vs, ok := a.(string)
-			if !ok {
-				return false
+			if vs, ok := a.(string); ok {
+				aud = append(aud, vs)
+			} else {
+				multierror.Append(err, fmt.Errorf("aud entry [%v] is not a string", a))
 			}
-			aud = append(aud, vs)
 		}
+	}
+	return aud, err.ErrorOrNil()
+}
+
+// VerifyAudience Compares the aud claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (m MapClaims) VerifyAudience(cmp string, req bool) bool {
+	aud, err := m.Audience()
+	if err != nil {
+		return false
 	}
 	return verifyAud(aud, cmp, req)
 }
@@ -36,26 +114,7 @@ func (m MapClaims) VerifyAudience(cmp string, req bool) bool {
 // If req is false, it will return true, if exp is unset.
 func (m MapClaims) VerifyExpiresAt(cmp int64, req bool) bool {
 	cmpTime := time.Unix(cmp, 0)
-
-	v, ok := m["exp"]
-	if !ok {
-		return !req
-	}
-
-	switch exp := v.(type) {
-	case float64:
-		if exp == 0 {
-			return verifyExp(nil, cmpTime, req)
-		}
-
-		return verifyExp(&newNumericDateFromSeconds(exp).Time, cmpTime, req)
-	case json.Number:
-		v, _ := exp.Float64()
-
-		return verifyExp(&newNumericDateFromSeconds(v).Time, cmpTime, req)
-	}
-
-	return false
+	return verifyExp(m.ExpiresAt(), cmpTime, req)
 }
 
 // VerifyIssuedAt compares the exp claim against cmp (cmp >= iat).
@@ -73,11 +132,9 @@ func (m MapClaims) VerifyIssuedAt(cmp int64, req bool) bool {
 		if iat == 0 {
 			return verifyIat(nil, cmpTime, req)
 		}
-
 		return verifyIat(&newNumericDateFromSeconds(iat).Time, cmpTime, req)
 	case json.Number:
 		v, _ := iat.Float64()
-
 		return verifyIat(&newNumericDateFromSeconds(v).Time, cmpTime, req)
 	}
 
@@ -87,34 +144,13 @@ func (m MapClaims) VerifyIssuedAt(cmp int64, req bool) bool {
 // VerifyNotBefore compares the nbf claim against cmp (cmp >= nbf).
 // If req is false, it will return true, if nbf is unset.
 func (m MapClaims) VerifyNotBefore(cmp int64, req bool) bool {
-	cmpTime := time.Unix(cmp, 0)
-
-	v, ok := m["nbf"]
-	if !ok {
-		return !req
-	}
-
-	switch nbf := v.(type) {
-	case float64:
-		if nbf == 0 {
-			return verifyNbf(nil, cmpTime, req)
-		}
-
-		return verifyNbf(&newNumericDateFromSeconds(nbf).Time, cmpTime, req)
-	case json.Number:
-		v, _ := nbf.Float64()
-
-		return verifyNbf(&newNumericDateFromSeconds(v).Time, cmpTime, req)
-	}
-
-	return false
+	return verifyNbf(m.NotBefore(), time.Unix(cmp, 0), req)
 }
 
 // VerifyIssuer compares the iss claim against cmp.
 // If required is false, this method will return true if the value matches or is unset
 func (m MapClaims) VerifyIssuer(cmp string, req bool) bool {
-	iss, _ := m["iss"].(string)
-	return verifyIss(iss, cmp, req)
+	return verifyIss(m.Issuer(), cmp, req)
 }
 
 // Valid validates time based claims "exp, iat, nbf".
@@ -122,27 +158,27 @@ func (m MapClaims) VerifyIssuer(cmp string, req bool) bool {
 // As well, if any of the above claims are not in the token, it will still
 // be considered a valid claim.
 func (m MapClaims) Valid() error {
-	vErr := new(ValidationError)
-	now := TimeFunc().Unix()
-
-	if !m.VerifyExpiresAt(now, false) {
-		vErr.Inner = errors.New("Token is expired")
-		vErr.Errors |= ValidationErrorExpired
+	var result *multierror.Error
+	now := TimeFunc()
+	nowUnix := now.Unix()
+	if !m.VerifyExpiresAt(nowUnix, false) {
+		result = multierror.Append(result, &ExpiredError{
+			ExpiredAt:   *m.ExpiresAt(),
+			AttemptedAt: now,
+		})
 	}
-
-	if !m.VerifyIssuedAt(now, false) {
-		vErr.Inner = errors.New("Token used before issued")
-		vErr.Errors |= ValidationErrorIssuedAt
+	if !m.VerifyIssuedAt(nowUnix, false) {
+		result = multierror.Append(result, &UsedBeforeIssuedError{
+			IssuedAt:    *m.IssuedAt(),
+			AttemptedAt: now,
+		})
 	}
-
-	if !m.VerifyNotBefore(now, false) {
-		vErr.Inner = errors.New("Token is not valid yet")
-		vErr.Errors |= ValidationErrorNotValidYet
+	if !m.VerifyNotBefore(nowUnix, false) {
+		result = multierror.Append(result, &NotYetValidError{
+			ValidAt:     *m.NotBefore(),
+			AttemptedAt: now,
+		})
 	}
+	return result.ErrorOrNil()
 
-	if vErr.valid() {
-		return nil
-	}
-
-	return vErr
 }

--- a/parser.go
+++ b/parser.go
@@ -3,7 +3,6 @@ package jwt
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"strings"
 )
 
@@ -23,7 +22,7 @@ func (p *Parser) Parse(tokenString string, keyFunc Keyfunc) (*Token, error) {
 func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyfunc) (*Token, error) {
 	token, parts, err := p.ParseUnverified(tokenString, claims)
 	if err != nil {
-		return token, err
+		return nil, err
 	}
 
 	// Verify signing method is in the required set
@@ -38,7 +37,7 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
 		}
 		if !signingMethodValid {
 			// signing method is not in the listed set
-			return token, NewValidationError(fmt.Sprintf("signing method %v is invalid", alg), ValidationErrorSignatureInvalid)
+			return nil, &InvalidSigningMethodError{Alg: alg}
 		}
 	}
 
@@ -46,45 +45,29 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
 	var key interface{}
 	if keyFunc == nil {
 		// keyFunc was not provided.  short circuiting validation
-		return token, NewValidationError("no Keyfunc was provided.", ValidationErrorUnverifiable)
-	}
-	if key, err = keyFunc(token); err != nil {
-		// keyFunc returned an error
-		if ve, ok := err.(*ValidationError); ok {
-			return token, ve
-		}
-		return token, &ValidationError{Inner: err, Errors: ValidationErrorUnverifiable}
+		return nil, ErrMissingKeyFunc
 	}
 
-	vErr := &ValidationError{}
+	key, err = keyFunc(token)
+	if err != nil {
+		return nil, err
+	}
 
 	// Validate Claims
 	if !p.SkipClaimsValidation {
 		if err := token.Claims.Valid(); err != nil {
-
-			// If the Claims Valid returned an error, check if it is a validation error,
-			// If it was another error type, create a ValidationError with a generic ClaimsInvalid flag set
-			if e, ok := err.(*ValidationError); !ok {
-				vErr = &ValidationError{Inner: err, Errors: ValidationErrorClaimsInvalid}
-			} else {
-				vErr = e
-			}
+			return nil, err
 		}
 	}
 
 	// Perform validation
 	token.Signature = parts[2]
 	if err = token.Method.Verify(strings.Join(parts[0:2], "."), token.Signature, key); err != nil {
-		vErr.Inner = err
-		vErr.Errors |= ValidationErrorSignatureInvalid
+		token.Valid = false
+		return token, err
 	}
-
-	if vErr.valid() {
-		token.Valid = true
-		return token, nil
-	}
-
-	return token, vErr
+	token.Valid = true
+	return token, nil
 }
 
 // ParseUnverified parses the token but doesn't validate the signature.
@@ -96,29 +79,32 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
 func (p *Parser) ParseUnverified(tokenString string, claims Claims) (token *Token, parts []string, err error) {
 	parts = strings.Split(tokenString, ".")
 	if len(parts) != 3 {
-		return nil, parts, NewValidationError("token contains an invalid number of segments", ValidationErrorMalformed)
+		return nil, parts, MalformedTokenError("token contains an invalid number of segments")
 	}
 
 	token = &Token{Raw: tokenString}
 
 	// parse Header
 	var headerBytes []byte
-	if headerBytes, err = DecodeSegment(parts[0]); err != nil {
+	headerBytes, err = DecodeSegment(parts[0])
+	if err != nil {
 		if strings.HasPrefix(strings.ToLower(tokenString), "bearer ") {
-			return token, parts, NewValidationError("tokenstring should not contain 'bearer '", ValidationErrorMalformed)
+			return token, parts, MalformedTokenError(`token may not contain "bearer "`)
 		}
-		return token, parts, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
+		return token, parts, MalformedTokenError(err.Error())
 	}
+
 	if err = json.Unmarshal(headerBytes, &token.Header); err != nil {
-		return token, parts, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
+		return token, parts, MalformedTokenError(err.Error())
 	}
 
 	// parse Claims
 	var claimBytes []byte
 	token.Claims = claims
 
-	if claimBytes, err = DecodeSegment(parts[1]); err != nil {
-		return token, parts, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
+	claimBytes, err = DecodeSegment(parts[1])
+	if err != nil {
+		return token, parts, MalformedTokenError(err.Error())
 	}
 	dec := json.NewDecoder(bytes.NewBuffer(claimBytes))
 	if p.UseJSONNumber {
@@ -132,17 +118,18 @@ func (p *Parser) ParseUnverified(tokenString string, claims Claims) (token *Toke
 	}
 	// Handle decode error
 	if err != nil {
-		return token, parts, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
+		return token, parts, MalformedTokenError(err.Error())
 	}
 
 	// Lookup signature method
-	if method, ok := token.Header["alg"].(string); ok {
-		if token.Method = GetSigningMethod(method); token.Method == nil {
-			return token, parts, NewValidationError("signing method (alg) is unavailable.", ValidationErrorUnverifiable)
-		}
-	} else {
-		return token, parts, NewValidationError("signing method (alg) is unspecified.", ValidationErrorUnverifiable)
-	}
 
+	alg, ok := token.Header["alg"].(string)
+	if !ok {
+		return token, parts, MalformedTokenError("signing method (alg) not specified")
+	}
+	token.Method = GetSigningMethod(alg)
+	if token.Method == nil {
+		return token, parts, &UnregisteredSigningMethodError{Alg: alg}
+	}
 	return token, parts, nil
 }

--- a/signing_method.go
+++ b/signing_method.go
@@ -4,8 +4,10 @@ import (
 	"sync"
 )
 
-var signingMethods = map[string]func() SigningMethod{}
-var signingMethodLock = new(sync.RWMutex)
+type signingMethodFunc = func() SigningMethod
+
+var signingMethods = map[string]signingMethodFunc{}
+var signingMethodsMutex = new(sync.Mutex)
 
 // SigningMethod can be used add new methods for signing or verifying tokens.
 type SigningMethod interface {
@@ -17,19 +19,20 @@ type SigningMethod interface {
 // RegisterSigningMethod registers the "alg" name and a factory function for signing method.
 // This is typically done during init() in the method's implementation
 func RegisterSigningMethod(alg string, f func() SigningMethod) {
-	signingMethodLock.Lock()
-	defer signingMethodLock.Unlock()
-
-	signingMethods[alg] = f
+	signingMethodsMutex.Lock()
+	defer signingMethodsMutex.Unlock()
+	clone := map[string]signingMethodFunc{}
+	for k, sm := range signingMethods {
+		clone[k] = sm
+	}
+	clone[alg] = f
+	signingMethods = clone
 }
 
 // GetSigningMethod retrieves a signing method from an "alg" string
-func GetSigningMethod(alg string) (method SigningMethod) {
-	signingMethodLock.RLock()
-	defer signingMethodLock.RUnlock()
-
+func GetSigningMethod(alg string) SigningMethod {
 	if methodF, ok := signingMethods[alg]; ok {
-		method = methodF()
+		return methodF()
 	}
-	return
+	return nil
 }


### PR DESCRIPTION
This isn't done as the tests haven't been verified but this moves errors to go 1.13. I can finish it but I don't want to burn a lot of time if you aren't interested in the changes.

There may be too many errors, especially around signing methods, but maybe not. It definitely helps to be able to narrow down what the problem is.

This pull request also:
- adds accessors to `MapClaims`
- changes the way signing methods are accessed. I changed the `RWMutex` guarding the global map of `signingMethods` to a `Mutex`. It is only locked when `RegisterSigningMethod` is called. The `signingMethods` map is then copied assigned over the existing map, removing the need to have a mutex on reads.