### PR TITLE
Add unit test cases to parse JWT tokens signed with ECDSA keys

### DIFF
--- a/request/request_test.go
+++ b/request/request_test.go
@@ -65,7 +65,7 @@ func TestParseRequest(t *testing.T) {
 	// Bearer token request
 	for _, data := range requestTestData {
 		// Make token from claims
-		tokenString := test.MakeSampleToken(data.claims, privateKey)
+		tokenString := test.MakeSampleToken(data.claims, jwt.SigningMethodRS256, privateKey)
 
 		// Make query string
 		for k, vv := range data.query {

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"crypto"
 	"crypto/rsa"
 	"io/ioutil"
 
@@ -31,8 +32,9 @@ func LoadRSAPublicKeyFromDisk(location string) *rsa.PublicKey {
 	return key
 }
 
-func MakeSampleToken(c jwt.Claims, key interface{}) string {
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, c)
+// MakeSampleToken creates and returns a encoded JWT token that has been signed with the specified cryptographic key.
+func MakeSampleToken(c jwt.Claims, method jwt.SigningMethod, key interface{}) string {
+	token := jwt.NewWithClaims(method, c)
 	s, e := token.SignedString(key)
 
 	if e != nil {
@@ -40,4 +42,28 @@ func MakeSampleToken(c jwt.Claims, key interface{}) string {
 	}
 
 	return s
+}
+
+func LoadECPrivateKeyFromDisk(location string) crypto.PrivateKey {
+	keyData, e := ioutil.ReadFile(location)
+	if e != nil {
+		panic(e.Error())
+	}
+	key, e := jwt.ParseECPrivateKeyFromPEM(keyData)
+	if e != nil {
+		panic(e.Error())
+	}
+	return key
+}
+
+func LoadECPublicKeyFromDisk(location string) crypto.PublicKey {
+	keyData, e := ioutil.ReadFile(location)
+	if e != nil {
+		panic(e.Error())
+	}
+	key, e := jwt.ParseECPublicKeyFromPEM(keyData)
+	if e != nil {
+		panic(e.Error())
+	}
+	return key
 }


### PR DESCRIPTION
In parse_test.go:
1. add test case where the JWT token is signed with a ECDSA private key and "EC256" is in the list of accepted algorithms.
1. add test case where the JWT token is signed with a ECDSA private key but "EC256" is NOT in the list of accepted algorithms.
1. Add validation for Token.Valid and Token.Signature in the unit tests. 