### PR TITLE
fix the comment of VerifyExpiresAt

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -83,7 +83,7 @@ func (c *RegisteredClaims) VerifyAudience(cmp string, req bool) bool {
 	return verifyAud(c.Audience, cmp, req)
 }
 
-// VerifyExpiresAt compares the exp claim against cmp (cmp <= exp).
+// VerifyExpiresAt compares the exp claim against cmp (cmp < exp).
 // If req is false, it will return true, if exp is unset.
 func (c *RegisteredClaims) VerifyExpiresAt(cmp time.Time, req bool) bool {
 	if c.ExpiresAt == nil {
@@ -170,7 +170,7 @@ func (c *StandardClaims) VerifyAudience(cmp string, req bool) bool {
 	return verifyAud([]string{c.Audience}, cmp, req)
 }
 
-// VerifyExpiresAt compares the exp claim against cmp (cmp <= exp).
+// VerifyExpiresAt compares the exp claim against cmp (cmp < exp).
 // If req is false, it will return true, if exp is unset.
 func (c *StandardClaims) VerifyExpiresAt(cmp int64, req bool) bool {
 	if c.ExpiresAt == 0 {


### PR DESCRIPTION
https://github.com/golang-jwt/jwt/pull/86 removes `cmp == exp` from the valid condition of the `exp`,
but it looks that the comments are not updated.