### PR TITLE
Fix int64 overflow in newNumericDateFromSeconds

### DIFF
--- a/types.go
+++ b/types.go
@@ -3,6 +3,7 @@ package jwt
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"reflect"
 	"strconv"
 	"time"
@@ -41,7 +42,8 @@ func NewNumericDate(t time.Time) *NumericDate {
 // newNumericDateFromSeconds creates a new *NumericDate out of a float64 representing a
 // UNIX epoch with the float fraction representing non-integer seconds.
 func newNumericDateFromSeconds(f float64) *NumericDate {
-	return NewNumericDate(time.Unix(0, int64(f*float64(time.Second))))
+	round, frac := math.Modf(f)
+	return NewNumericDate(time.Unix(int64(round), int64(frac*1e9)))
 }
 
 // MarshalJSON is an implementation of the json.RawMessage interface and serializes the UNIX epoch


### PR DESCRIPTION
`int64(f*float64(time.Second))` may easily overflow (this bug occured for me when validating token). I suggest here alternative approach to parse `NumericDate`.