### PR TITLE
Fixes jwt command to support EdDSA algorithm

### DIFF
--- a/cmd/jwt/main.go
+++ b/cmd/jwt/main.go
@@ -293,7 +293,7 @@ func isRs() bool {
 }
 
 func isEd() bool {
-	return strings.HasPrefix(strings.ToUpper(*flagAlg), "Ed")
+	return *flagAlg == "EdDSA"
 }
 
 type ArgList map[string]string


### PR DESCRIPTION
Fixes
```
$ echo '{"foo":"bar"}' | jwt -key test/ed25519-private.pem -alg EdDSA -sign -
Error: error signing token: key is of invalid type
```

Signed-off-by: Alexander Yastrebov <yastrebov.alex@gmail.com>