### PR TITLE
cmd: list supported algorithms

### DIFF
--- a/cmd/jwt/main.go
+++ b/cmd/jwt/main.go
@@ -14,6 +14,7 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -21,7 +22,7 @@ import (
 
 var (
 	// Options
-	flagAlg     = flag.String("alg", "", "signing algorithm identifier")
+	flagAlg     = flag.String("alg", "", algHelp())
 	flagKey     = flag.String("key", "", "path to key file or '-' to read from stdin")
 	flagCompact = flag.Bool("compact", false, "output compact JSON")
 	flagDebug   = flag.Bool("debug", false, "print out all kinds of debug data")
@@ -305,6 +306,25 @@ func isEd() bool {
 
 func isNone() bool {
 	return *flagAlg == "none"
+}
+
+func algHelp() string {
+	algs := jwt.GetAlgorithms()
+	sort.Strings(algs)
+
+	var b strings.Builder
+	b.WriteString("signing algorithm identifier, one of\n")
+	for i, alg := range algs {
+		if i > 0 {
+			if i%7 == 0 {
+				b.WriteString(",\n")
+			} else {
+				b.WriteString(", ")
+			}
+		}
+		b.WriteString(alg)
+	}
+	return b.String()
 }
 
 type ArgList map[string]string

--- a/signing_method.go
+++ b/signing_method.go
@@ -33,3 +33,14 @@ func GetSigningMethod(alg string) (method SigningMethod) {
 	}
 	return
 }
+
+// GetAlgorithms returns a list of registered "alg" names
+func GetAlgorithms() (algs []string) {
+	signingMethodLock.RLock()
+	defer signingMethodLock.RUnlock()
+
+	for alg := range signingMethods {
+		algs = append(algs, alg)
+	}
+	return
+}


### PR DESCRIPTION
The help message looks like:
```
  -alg string
        signing algorithm identifier, one of
        ES256, ES384, ES512, EdDSA, HS256, HS384, HS512,
        PS256, PS384, PS512, RS256, RS384, RS512, none
```

Also fixes #63

Signed-off-by: Alexander Yastrebov <yastrebov.alex@gmail.com>