### PR TITLE
Unwrap for ValidationError

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -53,6 +53,11 @@ func (e ValidationError) Error() string {
 	}
 }
 
+// Unwrap gives errors.Is and errors.As access to the inner error.
+func (e *ValidationError) Unwrap() error {
+	return e.Inner
+}
+
 // No errors
 func (e *ValidationError) valid() bool {
 	return e.Errors == 0


### PR DESCRIPTION
This PR adds a single Unwrap function to the ValidationError.

With this function, it is possible to call `errors.Is(err, target)` or `errors.As(err, &target)` with the error returned by e.g. `ParseWithClaims`.

More specifically, it allows one to replace
```
       _, err := jwt.ParseWithClaims(...)

	var valErr *jwt.ValidationError
	if errors.As(err, &valErr) {
		if errors.Is(valErr, myErrorType) {
			// do X
		} else {
                        // do Y
                }
	}
```
with
```
       _, err := jwt.ParseWithClaims(...)
       if errors.Is(err, myErrorType) {
           // do X
       }  else {
           // do Y
       }
```