### PR TITLE
Using `errors.As` to check for validation errors

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,6 +1,7 @@
 package jwt_test
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -94,16 +95,22 @@ func ExampleParseWithClaims_customClaimsType() {
 
 // An example of parsing the error types using bitfield checks
 func ExampleParse_errorChecking() {
-	// Token from another example.  This token is expired
-	var tokenString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJleHAiOjE1MDAwLCJpc3MiOiJ0ZXN0In0.HE7fK0xOQwFEr4WDgRWj4teRPZ6i3GLwD5YCm6Pwu_c"
+	var (
+		token *jwt.Token
+		ve    *jwt.ValidationError
+		err   error
+	)
 
-	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+	// Token from another example.  This token is expired
+	tokenString := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJleHAiOjE1MDAwLCJpc3MiOiJ0ZXN0In0.HE7fK0xOQwFEr4WDgRWj4teRPZ6i3GLwD5YCm6Pwu_c"
+
+	token, err = jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 		return []byte("AllYourBase"), nil
 	})
 
 	if token.Valid {
 		fmt.Println("You look nice today")
-	} else if ve, ok := err.(*jwt.ValidationError); ok {
+	} else if errors.As(err, &ve) {
 		if ve.Errors&jwt.ValidationErrorMalformed != 0 {
 			fmt.Println("That's not even a token")
 		} else if ve.Errors&(jwt.ValidationErrorExpired|jwt.ValidationErrorNotValidYet) != 0 {

--- a/parser_test.go
+++ b/parser_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto"
 	"crypto/rsa"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -325,6 +326,7 @@ func TestParser_Parse(t *testing.T) {
 
 			// Parse the token
 			var token *jwt.Token
+			var ve *jwt.ValidationError
 			var err error
 			var parser = data.parser
 			if parser == nil {
@@ -361,15 +363,15 @@ func TestParser_Parse(t *testing.T) {
 				if err == nil {
 					t.Errorf("[%v] Expecting error. Didn't get one.", data.name)
 				} else {
+					if errors.As(err, &ve) {
+						// compare the bitfield part of the error
+						if e := ve.Errors; e != data.errors {
+							t.Errorf("[%v] Errors don't match expectation.  %v != %v", data.name, e, data.errors)
+						}
 
-					ve := err.(*jwt.ValidationError)
-					// compare the bitfield part of the error
-					if e := ve.Errors; e != data.errors {
-						t.Errorf("[%v] Errors don't match expectation.  %v != %v", data.name, e, data.errors)
-					}
-
-					if err.Error() == errKeyFuncError.Error() && ve.Inner != errKeyFuncError {
-						t.Errorf("[%v] Inner error does not match expectation.  %v != %v", data.name, ve.Inner, errKeyFuncError)
+						if err.Error() == errKeyFuncError.Error() && ve.Inner != errKeyFuncError {
+							t.Errorf("[%v] Inner error does not match expectation.  %v != %v", data.name, ve.Inner, errKeyFuncError)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This small PR encourages the use of the "new" Go 1.13 `errors.As` API to convert an error into our specific `ValidationError`.