### PR TITLE
Implementing `Is(err) bool` to support Go 1.13 style error checking

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -56,17 +56,17 @@ func (c RegisteredClaims) Valid() error {
 	// default value in Go, let's not fail the verification for them.
 	if !c.VerifyExpiresAt(now, false) {
 		delta := now.Sub(c.ExpiresAt.Time)
-		vErr.Inner = fmt.Errorf("token is expired by %v", delta)
+		vErr.Inner = fmt.Errorf("%s by %v", delta, ErrTokenExpired)
 		vErr.Errors |= ValidationErrorExpired
 	}
 
 	if !c.VerifyIssuedAt(now, false) {
-		vErr.Inner = fmt.Errorf("token used before issued")
+		vErr.Inner = ErrTokenUsedBeforeIssued
 		vErr.Errors |= ValidationErrorIssuedAt
 	}
 
 	if !c.VerifyNotBefore(now, false) {
-		vErr.Inner = fmt.Errorf("token is not valid yet")
+		vErr.Inner = ErrTokenNotValidYet
 		vErr.Errors |= ValidationErrorNotValidYet
 	}
 
@@ -143,17 +143,17 @@ func (c StandardClaims) Valid() error {
 	// default value in Go, let's not fail the verification for them.
 	if !c.VerifyExpiresAt(now, false) {
 		delta := time.Unix(now, 0).Sub(time.Unix(c.ExpiresAt, 0))
-		vErr.Inner = fmt.Errorf("token is expired by %v", delta)
+		vErr.Inner = fmt.Errorf("%s by %v", delta, ErrTokenExpired)
 		vErr.Errors |= ValidationErrorExpired
 	}
 
 	if !c.VerifyIssuedAt(now, false) {
-		vErr.Inner = fmt.Errorf("token used before issued")
+		vErr.Inner = ErrTokenUsedBeforeIssued
 		vErr.Errors |= ValidationErrorIssuedAt
 	}
 
 	if !c.VerifyNotBefore(now, false) {
-		vErr.Inner = fmt.Errorf("token is not valid yet")
+		vErr.Inner = ErrTokenNotValidYet
 		vErr.Errors |= ValidationErrorNotValidYet
 	}
 

--- a/errors.go
+++ b/errors.go
@@ -14,9 +14,13 @@ var (
 	ErrTokenUnverifiable     = errors.New("token is unverifiable")
 	ErrTokenSignatureInvalid = errors.New("token signature is invalid")
 
+	ErrTokenInvalidAudience  = errors.New("token has invalid audience")
 	ErrTokenExpired          = errors.New("token is expired")
 	ErrTokenUsedBeforeIssued = errors.New("token used before issued")
+	ErrTokenInvalidIssuer    = errors.New("token has invalid issuer")
 	ErrTokenNotValidYet      = errors.New("token is not valid yet")
+	ErrTokenInvalidId        = errors.New("token has invalid id")
+	ErrTokenInvalidClaims    = errors.New("token has invalid claims")
 )
 
 // The errors that might occur when parsing and validating a token
@@ -71,9 +75,9 @@ func (e *ValidationError) valid() bool {
 	return e.Errors == 0
 }
 
-// Is checks if this ValidationError is of the supplied error type. We are first checking for the exact error message
-// by suppling the inner message. If that fails, we the error flags. This way we can supply custom error messages
-// and still use errors.Is using the pre-supplied error variables.
+// Is checks if this ValidationError is of the supplied error. We are first checking for the exact error message
+// by comparing the inner error message. If that fails, we compare using the error flags. This way we can use
+// custom error messages (mainly for backwards compatability) and still leverage errors.Is using the global error variables.
 func (e *ValidationError) Is(err error) bool {
 	// Check, if our inner error is a direct match
 	if errors.Is(errors.Unwrap(e), err) {
@@ -88,12 +92,20 @@ func (e *ValidationError) Is(err error) bool {
 		return e.Errors&ValidationErrorUnverifiable != 0
 	case ErrTokenSignatureInvalid:
 		return e.Errors&ValidationErrorSignatureInvalid != 0
+	case ErrTokenInvalidAudience:
+		return e.Errors&ValidationErrorAudience != 0
 	case ErrTokenExpired:
 		return e.Errors&ValidationErrorExpired != 0
-	case ErrTokenNotValidYet:
-		return e.Errors&ValidationErrorNotValidYet != 0
 	case ErrTokenUsedBeforeIssued:
 		return e.Errors&ValidationErrorIssuedAt != 0
+	case ErrTokenInvalidIssuer:
+		return e.Errors&ValidationErrorIssuer != 0
+	case ErrTokenNotValidYet:
+		return e.Errors&ValidationErrorNotValidYet != 0
+	case ErrTokenInvalidId:
+		return e.Errors&ValidationErrorId != 0
+	case ErrTokenInvalidClaims:
+		return e.Errors&ValidationErrorClaimsInvalid != 0
 	}
 
 	return false

--- a/errors.go
+++ b/errors.go
@@ -87,7 +87,7 @@ func (e *ValidationError) Is(err error) bool {
 	case ErrTokenUnverifiable:
 		return e.Errors&ValidationErrorUnverifiable != 0
 	case ErrTokenSignatureInvalid:
-		return e.Errors&ValidationErrorUnverifiable != 0
+		return e.Errors&ValidationErrorSignatureInvalid != 0
 	case ErrTokenExpired:
 		return e.Errors&ValidationErrorExpired != 0
 	case ErrTokenNotValidYet:

--- a/errors.go
+++ b/errors.go
@@ -9,6 +9,14 @@ var (
 	ErrInvalidKey      = errors.New("key is invalid")
 	ErrInvalidKeyType  = errors.New("key is of invalid type")
 	ErrHashUnavailable = errors.New("the requested hash function is unavailable")
+
+	ErrTokenMalformed        = errors.New("token is malformed")
+	ErrTokenUnverifiable     = errors.New("token is unverifiable")
+	ErrTokenSignatureInvalid = errors.New("token signature is invalid")
+
+	ErrTokenExpired          = errors.New("token is expired")
+	ErrTokenUsedBeforeIssued = errors.New("token used before issued")
+	ErrTokenNotValidYet      = errors.New("token is not valid yet")
 )
 
 // The errors that might occur when parsing and validating a token
@@ -61,4 +69,32 @@ func (e *ValidationError) Unwrap() error {
 // No errors
 func (e *ValidationError) valid() bool {
 	return e.Errors == 0
+}
+
+// Is checks if this ValidationError is of the supplied error type. We are first checking for the exact error message
+// by suppling the inner message. If that fails, we the error flags. This way we can supply custom error messages
+// and still use errors.Is using the pre-supplied error variables.
+func (e *ValidationError) Is(err error) bool {
+	// Check, if our inner error is a direct match
+	if errors.Is(errors.Unwrap(e), err) {
+		return true
+	}
+
+	// Otherwise, we need to match using our error flags
+	switch err {
+	case ErrTokenMalformed:
+		return e.Errors&ValidationErrorMalformed != 0
+	case ErrTokenUnverifiable:
+		return e.Errors&ValidationErrorUnverifiable != 0
+	case ErrTokenSignatureInvalid:
+		return e.Errors&ValidationErrorUnverifiable != 0
+	case ErrTokenExpired:
+		return e.Errors&ValidationErrorExpired != 0
+	case ErrTokenNotValidYet:
+		return e.Errors&ValidationErrorNotValidYet != 0
+	case ErrTokenUsedBeforeIssued:
+		return e.Errors&ValidationErrorIssuedAt != 0
+	}
+
+	return false
 }

--- a/example_test.go
+++ b/example_test.go
@@ -1,6 +1,7 @@
 package jwt_test
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -94,24 +95,25 @@ func ExampleParseWithClaims_customClaimsType() {
 
 // An example of parsing the error types using bitfield checks
 func ExampleParse_errorChecking() {
-	// Token from another example.  This token is expired
-	var tokenString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJleHAiOjE1MDAwLCJpc3MiOiJ0ZXN0In0.HE7fK0xOQwFEr4WDgRWj4teRPZ6i3GLwD5YCm6Pwu_c"
+	var (
+		token *jwt.Token
+		err   error
+	)
 
-	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+	// Token from another example.  This token is expired
+	tokenString := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJleHAiOjE1MDAwLCJpc3MiOiJ0ZXN0In0.HE7fK0xOQwFEr4WDgRWj4teRPZ6i3GLwD5YCm6Pwu_c"
+
+	token, err = jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 		return []byte("AllYourBase"), nil
 	})
 
 	if token.Valid {
 		fmt.Println("You look nice today")
-	} else if ve, ok := err.(*jwt.ValidationError); ok {
-		if ve.Errors&jwt.ValidationErrorMalformed != 0 {
-			fmt.Println("That's not even a token")
-		} else if ve.Errors&(jwt.ValidationErrorExpired|jwt.ValidationErrorNotValidYet) != 0 {
-			// Token is either expired or not active yet
-			fmt.Println("Timing is everything")
-		} else {
-			fmt.Println("Couldn't handle this token:", err)
-		}
+	} else if errors.Is(err, jwt.ErrTokenMalformed) {
+		fmt.Println("That's not even a token")
+	} else if errors.Is(err, jwt.ErrTokenExpired) || errors.Is(err, jwt.ErrTokenNotValidYet) {
+		// Token is either expired or not active yet
+		fmt.Println("Timing is everything")
 	} else {
 		fmt.Println("Couldn't handle this token:", err)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -95,15 +95,10 @@ func ExampleParseWithClaims_customClaimsType() {
 
 // An example of parsing the error types using bitfield checks
 func ExampleParse_errorChecking() {
-	var (
-		token *jwt.Token
-		err   error
-	)
-
 	// Token from another example.  This token is expired
-	tokenString := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJleHAiOjE1MDAwLCJpc3MiOiJ0ZXN0In0.HE7fK0xOQwFEr4WDgRWj4teRPZ6i3GLwD5YCm6Pwu_c"
+	var tokenString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJleHAiOjE1MDAwLCJpc3MiOiJ0ZXN0In0.HE7fK0xOQwFEr4WDgRWj4teRPZ6i3GLwD5YCm6Pwu_c"
 
-	token, err = jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 		return []byte("AllYourBase"), nil
 	})
 

--- a/map_claims.go
+++ b/map_claims.go
@@ -126,16 +126,19 @@ func (m MapClaims) Valid() error {
 	now := TimeFunc().Unix()
 
 	if !m.VerifyExpiresAt(now, false) {
+		// TODO(oxisto): this should be replaced with ErrTokenExpired
 		vErr.Inner = errors.New("Token is expired")
 		vErr.Errors |= ValidationErrorExpired
 	}
 
 	if !m.VerifyIssuedAt(now, false) {
+		// TODO(oxisto): this should be replaced with ErrTokenUsedBeforeIssued
 		vErr.Inner = errors.New("Token used before issued")
 		vErr.Errors |= ValidationErrorIssuedAt
 	}
 
 	if !m.VerifyNotBefore(now, false) {
+		// TODO(oxisto): this should be replaced with ErrTokenNotValidYet
 		vErr.Inner = errors.New("Token is not valid yet")
 		vErr.Errors |= ValidationErrorNotValidYet
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -52,6 +52,7 @@ var jwtTestData = []struct {
 	claims        jwt.Claims
 	valid         bool
 	errors        uint32
+	err           []error
 	parser        *jwt.Parser
 	signingMethod jwt.SigningMethod // The method to sign the JWT token for test purpose
 }{
@@ -63,6 +64,7 @@ var jwtTestData = []struct {
 		true,
 		0,
 		nil,
+		nil,
 		jwt.SigningMethodRS256,
 	},
 	{
@@ -72,6 +74,7 @@ var jwtTestData = []struct {
 		jwt.MapClaims{"foo": "bar", "exp": float64(time.Now().Unix() - 100)},
 		false,
 		jwt.ValidationErrorExpired,
+		[]error{jwt.ErrTokenExpired},
 		nil,
 		jwt.SigningMethodRS256,
 	},
@@ -82,6 +85,7 @@ var jwtTestData = []struct {
 		jwt.MapClaims{"foo": "bar", "nbf": float64(time.Now().Unix() + 100)},
 		false,
 		jwt.ValidationErrorNotValidYet,
+		[]error{jwt.ErrTokenNotValidYet},
 		nil,
 		jwt.SigningMethodRS256,
 	},
@@ -92,6 +96,7 @@ var jwtTestData = []struct {
 		jwt.MapClaims{"foo": "bar", "nbf": float64(time.Now().Unix() + 100), "exp": float64(time.Now().Unix() - 100)},
 		false,
 		jwt.ValidationErrorNotValidYet | jwt.ValidationErrorExpired,
+		[]error{jwt.ErrTokenNotValidYet},
 		nil,
 		jwt.SigningMethodRS256,
 	},
@@ -102,6 +107,7 @@ var jwtTestData = []struct {
 		jwt.MapClaims{"foo": "bar"},
 		false,
 		jwt.ValidationErrorSignatureInvalid,
+		[]error{jwt.ErrTokenSignatureInvalid, rsa.ErrVerification},
 		nil,
 		jwt.SigningMethodRS256,
 	},
@@ -112,6 +118,7 @@ var jwtTestData = []struct {
 		jwt.MapClaims{"foo": "bar"},
 		false,
 		jwt.ValidationErrorUnverifiable,
+		[]error{jwt.ErrTokenUnverifiable},
 		nil,
 		jwt.SigningMethodRS256,
 	},
@@ -122,6 +129,7 @@ var jwtTestData = []struct {
 		jwt.MapClaims{"foo": "bar"},
 		false,
 		jwt.ValidationErrorSignatureInvalid,
+		[]error{jwt.ErrTokenSignatureInvalid},
 		nil,
 		jwt.SigningMethodRS256,
 	},
@@ -132,6 +140,7 @@ var jwtTestData = []struct {
 		jwt.MapClaims{"foo": "bar"},
 		false,
 		jwt.ValidationErrorUnverifiable,
+		[]error{jwt.ErrTokenUnverifiable, errKeyFuncError},
 		nil,
 		jwt.SigningMethodRS256,
 	},
@@ -142,6 +151,7 @@ var jwtTestData = []struct {
 		jwt.MapClaims{"foo": "bar"},
 		false,
 		jwt.ValidationErrorSignatureInvalid,
+		[]error{jwt.ErrTokenSignatureInvalid},
 		&jwt.Parser{ValidMethods: []string{"HS256"}},
 		jwt.SigningMethodRS256,
 	},
@@ -152,6 +162,7 @@ var jwtTestData = []struct {
 		jwt.MapClaims{"foo": "bar"},
 		true,
 		0,
+		nil,
 		&jwt.Parser{ValidMethods: []string{"RS256", "HS256"}},
 		jwt.SigningMethodRS256,
 	},
@@ -162,6 +173,7 @@ var jwtTestData = []struct {
 		jwt.MapClaims{"foo": "bar"},
 		false,
 		jwt.ValidationErrorSignatureInvalid,
+		[]error{jwt.ErrTokenSignatureInvalid},
 		&jwt.Parser{ValidMethods: []string{"RS256", "HS256"}},
 		jwt.SigningMethodES256,
 	},
@@ -172,6 +184,7 @@ var jwtTestData = []struct {
 		jwt.MapClaims{"foo": "bar"},
 		true,
 		0,
+		nil,
 		&jwt.Parser{ValidMethods: []string{"HS256", "ES256"}},
 		jwt.SigningMethodES256,
 	},
@@ -182,6 +195,7 @@ var jwtTestData = []struct {
 		jwt.MapClaims{"foo": json.Number("123.4")},
 		true,
 		0,
+		nil,
 		&jwt.Parser{UseJSONNumber: true},
 		jwt.SigningMethodRS256,
 	},
@@ -194,6 +208,7 @@ var jwtTestData = []struct {
 		},
 		true,
 		0,
+		nil,
 		&jwt.Parser{UseJSONNumber: true},
 		jwt.SigningMethodRS256,
 	},
@@ -204,6 +219,7 @@ var jwtTestData = []struct {
 		jwt.MapClaims{"foo": "bar", "exp": json.Number(fmt.Sprintf("%v", time.Now().Unix()-100))},
 		false,
 		jwt.ValidationErrorExpired,
+		[]error{jwt.ErrTokenExpired},
 		&jwt.Parser{UseJSONNumber: true},
 		jwt.SigningMethodRS256,
 	},
@@ -214,6 +230,7 @@ var jwtTestData = []struct {
 		jwt.MapClaims{"foo": "bar", "nbf": json.Number(fmt.Sprintf("%v", time.Now().Unix()+100))},
 		false,
 		jwt.ValidationErrorNotValidYet,
+		[]error{jwt.ErrTokenNotValidYet},
 		&jwt.Parser{UseJSONNumber: true},
 		jwt.SigningMethodRS256,
 	},
@@ -224,6 +241,7 @@ var jwtTestData = []struct {
 		jwt.MapClaims{"foo": "bar", "nbf": json.Number(fmt.Sprintf("%v", time.Now().Unix()+100)), "exp": json.Number(fmt.Sprintf("%v", time.Now().Unix()-100))},
 		false,
 		jwt.ValidationErrorNotValidYet | jwt.ValidationErrorExpired,
+		[]error{jwt.ErrTokenNotValidYet},
 		&jwt.Parser{UseJSONNumber: true},
 		jwt.SigningMethodRS256,
 	},
@@ -234,6 +252,7 @@ var jwtTestData = []struct {
 		jwt.MapClaims{"foo": "bar", "nbf": json.Number(fmt.Sprintf("%v", time.Now().Unix()+100))},
 		true,
 		0,
+		nil,
 		&jwt.Parser{UseJSONNumber: true, SkipClaimsValidation: true},
 		jwt.SigningMethodRS256,
 	},
@@ -246,6 +265,7 @@ var jwtTestData = []struct {
 		},
 		true,
 		0,
+		nil,
 		&jwt.Parser{UseJSONNumber: true},
 		jwt.SigningMethodRS256,
 	},
@@ -258,6 +278,7 @@ var jwtTestData = []struct {
 		},
 		true,
 		0,
+		nil,
 		&jwt.Parser{UseJSONNumber: true},
 		jwt.SigningMethodRS256,
 	},
@@ -270,6 +291,7 @@ var jwtTestData = []struct {
 		},
 		true,
 		0,
+		nil,
 		&jwt.Parser{UseJSONNumber: true},
 		jwt.SigningMethodRS256,
 	},
@@ -282,6 +304,7 @@ var jwtTestData = []struct {
 		},
 		false,
 		jwt.ValidationErrorMalformed,
+		[]error{jwt.ErrTokenMalformed},
 		&jwt.Parser{UseJSONNumber: true},
 		jwt.SigningMethodRS256,
 	},
@@ -294,6 +317,7 @@ var jwtTestData = []struct {
 		},
 		false,
 		jwt.ValidationErrorMalformed,
+		[]error{jwt.ErrTokenMalformed},
 		&jwt.Parser{UseJSONNumber: true},
 		jwt.SigningMethodRS256,
 	},
@@ -375,6 +399,22 @@ func TestParser_Parse(t *testing.T) {
 					}
 				}
 			}
+
+			if data.err != nil {
+				if err == nil {
+					t.Errorf("[%v] Expecting error(s). Didn't get one.", data.name)
+				} else {
+					var all = false
+					for _, e := range data.err {
+						all = errors.Is(err, e)
+					}
+
+					if !all {
+						t.Errorf("[%v] Errors don't match expectation.  %v should contain all of %v", data.name, err, data.err)
+					}
+				}
+			}
+
 			if data.valid {
 				if token.Signature == "" {
 					t.Errorf("[%v] Signature is left unpopulated after parsing", data.name)

--- a/parser_test.go
+++ b/parser_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto"
 	"crypto/rsa"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -325,6 +326,7 @@ func TestParser_Parse(t *testing.T) {
 
 			// Parse the token
 			var token *jwt.Token
+			var ve *jwt.ValidationError
 			var err error
 			var parser = data.parser
 			if parser == nil {
@@ -361,15 +363,15 @@ func TestParser_Parse(t *testing.T) {
 				if err == nil {
 					t.Errorf("[%v] Expecting error. Didn't get one.", data.name)
 				} else {
+					if errors.As(err, &ve) {
+						// compare the bitfield part of the error
+						if e := ve.Errors; e != data.errors {
+							t.Errorf("[%v] Errors don't match expectation.  %v != %v", data.name, e, data.errors)
+						}
 
-					ve := err.(*jwt.ValidationError)
-					// compare the bitfield part of the error
-					if e := ve.Errors; e != data.errors {
-						t.Errorf("[%v] Errors don't match expectation.  %v != %v", data.name, e, data.errors)
-					}
-
-					if err.Error() == errKeyFuncError.Error() && ve.Inner != errKeyFuncError {
-						t.Errorf("[%v] Inner error does not match expectation.  %v != %v", data.name, ve.Inner, errKeyFuncError)
+						if err.Error() == errKeyFuncError.Error() && ve.Inner != errKeyFuncError {
+							t.Errorf("[%v] Inner error does not match expectation.  %v != %v", data.name, ve.Inner, errKeyFuncError)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Fixes #135 by implementing `Is(err) bool` for the `ValidationError`. It both checks
for the actual inner error message as well as our error flags for maximum backwards compatibility
