### PR TITLE
Support `errors.Is` for token extractors

### DIFF
--- a/request/extractor.go
+++ b/request/extractor.go
@@ -58,7 +58,7 @@ func (e MultiExtractor) ExtractToken(req *http.Request) (string, error) {
 	for _, extractor := range e {
 		if tok, err := extractor.ExtractToken(req); tok != "" {
 			return tok, nil
-		} else if err != ErrNoTokenInRequest {
+		} else if !errors.Is(err, ErrNoTokenInRequest) {
 			return "", err
 		}
 	}


### PR DESCRIPTION
This PR changes how the extractor expected error `ErrNoTokenInRequest ` is checked.
This allows implementations of the `Extractor` interface to wrap errors as suggested since Go 1.13. This is mainly interesting for external Extractor implementations.

This is consistent with the direction the errors are [refactored in the `jwt` package](https://github.com/golang-jwt/jwt/pull/136). I therefore allowed myself not to open an issue first.

As the two are conceptually related, I could also open a PR towards that branch if that is desired but my understanding is that PR #136 focuses on the validation errors. @oxisto WDYT?