### PR TITLE
updated README.md to contain more extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,15 @@ See [the project documentation](https://pkg.go.dev/github.com/golang-jwt/jwt) fo
 
 ## Extensions
 
-This library publishes all the necessary components for adding your own signing methods.  Simply implement the `SigningMethod` interface and register a factory method using `RegisterSigningMethod`.  
+This library publishes all the necessary components for adding your own signing methods.  Simply implement the `SigningMethod` interface and register a factory method using `RegisterSigningMethod`. 
 
-Here's an example of an extension that integrates with multiple Google Cloud Platform signing tools (AppEngine, IAM API, Cloud KMS): https://github.com/someone1/gcp-jwt-go
+A common use case would be integrating with different 3rd party signature providers, like key management services from various cloud providers or Hardware Security Modules (HSMs).
+
+| Extension | Purpose                                                                                      | Repo                                       |
+|-----------|----------------------------------------------------------------------------------------------|--------------------------------------------|
+| GCP       | Integrates with multiple Google Cloud Platform signing tools (AppEngine, IAM API, Cloud KMS) | https://github.com/someone1/gcp-jwt-go     |
+| AWS       | Integrates with AWS Key Management Service, KMS                                              | https://github.com/matelang/jwt-go-aws-kms |
+
 
 ## Compliance
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ A common use case would be integrating with different 3rd party signature provid
 | GCP       | Integrates with multiple Google Cloud Platform signing tools (AppEngine, IAM API, Cloud KMS) | https://github.com/someone1/gcp-jwt-go     |
 | AWS       | Integrates with AWS Key Management Service, KMS                                              | https://github.com/matelang/jwt-go-aws-kms |
 
+*Disclaimer*: Unless otherwise specified, these integrations are maintained by third parties and should not be considered as a primary offer by any of the mentioned cloud providers
 
 ## Compliance
 


### PR DESCRIPTION
I think it would be useful to include links to general purpose extensions besides the one already included for GCP.
I've added a short description and link to the AWS counterpart of the already included GCP SigningMethod lib.