### PR TITLE
Generation and parsing of jwt supports string type keys

### DIFF
--- a/hmac.go
+++ b/hmac.go
@@ -48,8 +48,14 @@ func (m *SigningMethodHMAC) Alg() string {
 // Verify implements token verification for the SigningMethod. Returns nil if the signature is valid.
 func (m *SigningMethodHMAC) Verify(signingString, signature string, key interface{}) error {
 	// Verify the key is the right type
-	keyBytes, ok := key.([]byte)
-	if !ok {
+	var keyBytes []byte
+
+	switch k := key.(type) {
+	case string:
+		keyBytes = StringToBytes(k)
+	case []byte:
+		keyBytes = k
+	default:
 		return ErrInvalidKeyType
 	}
 
@@ -78,18 +84,26 @@ func (m *SigningMethodHMAC) Verify(signingString, signature string, key interfac
 }
 
 // Sign implements token signing for the SigningMethod.
-// Key must be []byte
+// Key must be []byte, string
 func (m *SigningMethodHMAC) Sign(signingString string, key interface{}) (string, error) {
-	if keyBytes, ok := key.([]byte); ok {
-		if !m.Hash.Available() {
-			return "", ErrHashUnavailable
-		}
+	var keyBytes []byte
 
-		hasher := hmac.New(m.Hash.New, keyBytes)
-		hasher.Write([]byte(signingString))
-
-		return EncodeSegment(hasher.Sum(nil)), nil
+	switch k := key.(type) {
+	case string:
+		keyBytes = StringToBytes(k)
+	case []byte:
+		keyBytes = k
+	default:
+		return "", ErrInvalidKeyType
 	}
 
-	return "", ErrInvalidKeyType
+	if !m.Hash.Available() {
+		return "", ErrHashUnavailable
+	}
+
+	hasher := hmac.New(m.Hash.New, keyBytes)
+	hasher.Write([]byte(signingString))
+
+	return EncodeSegment(hasher.Sum(nil)), nil
+
 }

--- a/hmac_test.go
+++ b/hmac_test.go
@@ -48,17 +48,21 @@ var hmacTestData = []struct {
 // Sample data from http://tools.ietf.org/html/draft-jones-json-web-signature-04#appendix-A.1
 var hmacTestKey, _ = ioutil.ReadFile("test/hmacTestKey")
 
+var hmacTestKeyString = string(hmacTestKey)
+
 func TestHMACVerify(t *testing.T) {
 	for _, data := range hmacTestData {
 		parts := strings.Split(data.tokenString, ".")
 
 		method := jwt.GetSigningMethod(data.alg)
-		err := method.Verify(strings.Join(parts[0:2], "."), parts[2], hmacTestKey)
-		if data.valid && err != nil {
-			t.Errorf("[%v] Error while verifying key: %v", data.name, err)
-		}
-		if !data.valid && err == nil {
-			t.Errorf("[%v] Invalid key passed validation", data.name)
+		for _, hmacTestKey := range []interface{}{hmacTestKey, hmacTestKeyString} {
+			err := method.Verify(strings.Join(parts[0:2], "."), parts[2], hmacTestKey)
+			if data.valid && err != nil {
+				t.Errorf("[%v] Error while verifying key: %v", data.name, err)
+			}
+			if !data.valid && err == nil {
+				t.Errorf("[%v] Invalid key passed validation", data.name)
+			}
 		}
 	}
 }
@@ -68,12 +72,14 @@ func TestHMACSign(t *testing.T) {
 		if data.valid {
 			parts := strings.Split(data.tokenString, ".")
 			method := jwt.GetSigningMethod(data.alg)
-			sig, err := method.Sign(strings.Join(parts[0:2], "."), hmacTestKey)
-			if err != nil {
-				t.Errorf("[%v] Error signing token: %v", data.name, err)
-			}
-			if sig != parts[2] {
-				t.Errorf("[%v] Incorrect signature.\nwas:\n%v\nexpecting:\n%v", data.name, sig, parts[2])
+			for _, hmacTestKey := range []interface{}{hmacTestKey, hmacTestKeyString} {
+				sig, err := method.Sign(strings.Join(parts[0:2], "."), hmacTestKey)
+				if err != nil {
+					t.Errorf("[%v] Error signing token: %v", data.name, err)
+				}
+				if sig != parts[2] {
+					t.Errorf("[%v] Incorrect signature.\nwas:\n%v\nexpecting:\n%v", data.name, sig, parts[2])
+				}
 			}
 		}
 	}

--- a/string_to_bytes.go
+++ b/string_to_bytes.go
@@ -1,0 +1,15 @@
+package jwt
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+func StringToBytes(s string) (b []byte) {
+	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	bh.Data = sh.Data
+	bh.Len = sh.Len
+	bh.Cap = sh.Len
+	return b
+}


### PR DESCRIPTION
Type conversion, key will not allocate memory