### PR TITLE
Native support for key rotation in verifications

### DIFF
--- a/hmac_test.go
+++ b/hmac_test.go
@@ -63,6 +63,35 @@ func TestHMACVerify(t *testing.T) {
 	}
 }
 
+func TestHMACVerifyKeyRotation(t *testing.T) {
+	invalidKey1 := []byte("foo")
+	invalidKey2 := []byte("bar")
+	for _, data := range hmacTestData {
+		parts := strings.Split(data.tokenString, ".")
+
+		method := jwt.GetSigningMethod(data.alg)
+		err := method.Verify(strings.Join(parts[0:2], "."), parts[2], [][]byte{invalidKey1, hmacTestKey, invalidKey2})
+		if data.valid && err != nil {
+			t.Errorf("[%v] Error while verifying key: %v", data.name, err)
+		}
+		if !data.valid && err == nil {
+			t.Errorf("[%v] Invalid key passed validation", data.name)
+		}
+
+		if !data.valid {
+			continue
+		}
+		err = method.Verify(strings.Join(parts[0:2], "."), parts[2], [][]byte{})
+		if err == nil {
+			t.Errorf("[%v] Empty key list passed validation", data.name)
+		}
+		err = method.Verify(strings.Join(parts[0:2], "."), parts[2], [][]byte{invalidKey1, invalidKey2})
+		if err == nil {
+			t.Errorf("[%v] Key list with only invalid keys passed validation", data.name)
+		}
+	}
+}
+
 func TestHMACSign(t *testing.T) {
 	for _, data := range hmacTestData {
 		if data.valid {

--- a/rsa.go
+++ b/rsa.go
@@ -45,7 +45,8 @@ func (m *SigningMethodRSA) Alg() string {
 }
 
 // Verify implements token verification for the SigningMethod
-// For this signing method, must be an *rsa.PublicKey structure.
+// For this signing method, key must be in types of either *rsa.PublicKey or
+// []*rsa.PublicKey (for rotation keys).
 func (m *SigningMethodRSA) Verify(signingString, signature string, key interface{}) error {
 	var err error
 
@@ -55,22 +56,34 @@ func (m *SigningMethodRSA) Verify(signingString, signature string, key interface
 		return err
 	}
 
-	var rsaKey *rsa.PublicKey
-	var ok bool
-
-	if rsaKey, ok = key.(*rsa.PublicKey); !ok {
+	var keys []*rsa.PublicKey
+	switch v := key.(type) {
+	case *rsa.PublicKey:
+		keys = append(keys, v)
+	case []*rsa.PublicKey:
+		keys = v
+	}
+	if len(keys) == 0 {
 		return ErrInvalidKeyType
 	}
 
-	// Create hasher
 	if !m.Hash.Available() {
 		return ErrHashUnavailable
 	}
-	hasher := m.Hash.New()
-	hasher.Write([]byte(signingString))
 
-	// Verify the signature
-	return rsa.VerifyPKCS1v15(rsaKey, m.Hash, hasher.Sum(nil), sig)
+	var lastErr error
+	for _, rsaKey := range keys {
+		// Create hasher
+		hasher := m.Hash.New()
+		hasher.Write([]byte(signingString))
+
+		// Verify the signature
+		lastErr = rsa.VerifyPKCS1v15(rsaKey, m.Hash, hasher.Sum(nil), sig)
+		if lastErr == nil {
+			return nil
+		}
+	}
+	return lastErr
 }
 
 // Sign implements token signing for the SigningMethod

--- a/rsa_pss.go
+++ b/rsa_pss.go
@@ -1,3 +1,4 @@
+//go:build go1.4
 // +build go1.4
 
 package jwt
@@ -80,7 +81,8 @@ func init() {
 }
 
 // Verify implements token verification for the SigningMethod.
-// For this verify method, key must be an rsa.PublicKey struct
+// For this verify method, key must be in the types of either *rsa.PublicKey or
+// []*rsa.PublicKey (for rotation keys).
 func (m *SigningMethodRSAPSS) Verify(signingString, signature string, key interface{}) error {
 	var err error
 
@@ -90,27 +92,38 @@ func (m *SigningMethodRSAPSS) Verify(signingString, signature string, key interf
 		return err
 	}
 
-	var rsaKey *rsa.PublicKey
-	switch k := key.(type) {
+	var keys []*rsa.PublicKey
+	switch v := key.(type) {
 	case *rsa.PublicKey:
-		rsaKey = k
-	default:
-		return ErrInvalidKey
+		keys = append(keys, v)
+	case []*rsa.PublicKey:
+		keys = v
+	}
+	if len(keys) == 0 {
+		return ErrInvalidKeyType
 	}
 
-	// Create hasher
 	if !m.Hash.Available() {
 		return ErrHashUnavailable
 	}
-	hasher := m.Hash.New()
-	hasher.Write([]byte(signingString))
 
-	opts := m.Options
-	if m.VerifyOptions != nil {
-		opts = m.VerifyOptions
+	var lastErr error
+	for _, rsaKey := range keys {
+		// Create hasher
+		hasher := m.Hash.New()
+		hasher.Write([]byte(signingString))
+
+		opts := m.Options
+		if m.VerifyOptions != nil {
+			opts = m.VerifyOptions
+		}
+
+		lastErr = rsa.VerifyPSS(rsaKey, m.Hash, hasher.Sum(nil), sig, opts)
+		if lastErr == nil {
+			return nil
+		}
 	}
-
-	return rsa.VerifyPSS(rsaKey, m.Hash, hasher.Sum(nil), sig, opts)
+	return lastErr
 }
 
 // Sign implements token signing for the SigningMethod.

--- a/rsa_pss_test.go
+++ b/rsa_pss_test.go
@@ -70,6 +70,18 @@ func TestRSAPSSVerify(t *testing.T) {
 		if !data.valid && err == nil {
 			t.Errorf("[%v] Invalid key passed validation", data.name)
 		}
+
+		if !data.valid {
+			continue
+		}
+		err = method.Verify(strings.Join(parts[0:2], "."), parts[2], []*rsa.PublicKey{rsaPSSKey})
+		if err != nil {
+			t.Errorf("[%v] Error while verifying key list: %v", data.name, err)
+		}
+		err = method.Verify(strings.Join(parts[0:2], "."), parts[2], []*rsa.PublicKey{})
+		if err == nil {
+			t.Errorf("[%v] Empty key list passed validation", data.name)
+		}
 	}
 }
 

--- a/rsa_test.go
+++ b/rsa_test.go
@@ -1,11 +1,37 @@
 package jwt_test
 
 import (
+	"crypto/rsa"
 	"io/ioutil"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/golang-jwt/jwt/v4"
+)
+
+// 2 valid rsa pubkeys that's not the one used to sign the payload
+const (
+	wrongRSAPubKeyData1 = `
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAycU1W/hMRWNLkaJPEwWg
+j36URuSaRTV0BEvY+L0nRseCnEdlIsj8LCI+ydk3HlJqj3QicuCP9U0W5JAP4PYB
+Xs+dV/J38fqdYfI1myXRG2wU5USziF3OC3YYZIXiPe41IltP7LSUmyRO/F6jAcUj
+ZmRP2sxhIjY/77nQbx1F3ZMF2i91CRyaIfyd2pC8pwA4VElBTZaP9j3xXEsA8VIX
+F/PSVcDsm3GoxVkwQbJTr54GedsRMoex574rvt8iujiNQ7Cb0uXWFIfnlD1thnne
+4ws5ekuVhT6lq1KDB2z4e/pN2cOEzzSmfJJK1AWS79R4sAO8Fm/8cpWx6MRhlAbv
+HwIDAQAB
+-----END PUBLIC KEY-----`
+	wrongRSAPubKeyData2 = `
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA06q+yHMtXDj3qa3qELcg
+bS/48HWbylEi+smx+xa8yupMTMtne6WFvxiS3lU/+TXQj+hdHzwpLj+W24QCON1o
+JqxYDLWVJ2YpmrwkU/IDbhoPKfpYchy6Zmg2bnr93FDcvc4oL2/UYaiG+3w8fS+D
+BcHug7ILLmY5RnwqzdcYfQ5waX2QCK75kmtB+TBqtS3xAr2m2omdla91YeARSu3O
+lVjB6h9QNfbR6KCZRalMWlNGpp0tG0faU9mEescY4zfqt2inQFAr+MuXjJhg0tW8
+kO6LskiW1+SbBlNrJeQDXUjC/vz6/8X1DvDeczd9tqbAxfV57yRjIxkfsDYxehai
+6QIDAQAB
+-----END PUBLIC KEY-----`
 )
 
 var rsaTestData = []struct {
@@ -48,6 +74,8 @@ var rsaTestData = []struct {
 func TestRSAVerify(t *testing.T) {
 	keyData, _ := ioutil.ReadFile("test/sample_key.pub")
 	key, _ := jwt.ParseRSAPublicKeyFromPEM(keyData)
+	wrongKey1, _ := jwt.ParseRSAPublicKeyFromPEM([]byte(wrongRSAPubKeyData1))
+	wrongKey2, _ := jwt.ParseRSAPublicKeyFromPEM([]byte(wrongRSAPubKeyData2))
 
 	for _, data := range rsaTestData {
 		parts := strings.Split(data.tokenString, ".")
@@ -59,6 +87,25 @@ func TestRSAVerify(t *testing.T) {
 		}
 		if !data.valid && err == nil {
 			t.Errorf("[%v] Invalid key passed validation", data.name)
+		}
+
+		// test key rotations
+		err = method.Verify(strings.Join(parts[0:2], "."), parts[2], []*rsa.PublicKey{})
+		if err == nil {
+			t.Errorf("[%v] Empty key list passed validation", data.name)
+		}
+		err = method.Verify(strings.Join(parts[0:2], "."), parts[2], []*rsa.PublicKey{wrongKey1, wrongKey2})
+		if err == nil {
+			t.Errorf("[%v] Wrong keys passed validation", data.name)
+		}
+
+		if !data.valid {
+			continue
+		}
+
+		err = method.Verify(strings.Join(parts[0:2], "."), parts[2], []*rsa.PublicKey{wrongKey1, key, wrongKey2})
+		if err != nil {
+			t.Errorf("[%v] Error while verifying key list: %v", data.name, err)
 		}
 	}
 }
@@ -197,4 +244,152 @@ func BenchmarkRS512Signing(b *testing.B) {
 	}
 
 	benchmarkSigning(b, jwt.SigningMethodRS512, parsedKey)
+}
+
+func validateWithManualRotation(payload string, keys []*rsa.PublicKey) bool {
+	claims := new(jwt.RegisteredClaims)
+	for _, key := range keys {
+		token, err := jwt.ParseWithClaims(payload, claims, func(_ *jwt.Token) (interface{}, error) {
+			return key, nil
+		})
+		if err != nil {
+			continue
+		}
+		if !token.Valid {
+			continue
+		}
+		if _, ok := token.Claims.(*jwt.RegisteredClaims); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func validateWithNativeRotation(payload string, keys []*rsa.PublicKey) bool {
+
+	token, err := jwt.ParseWithClaims(payload, new(jwt.RegisteredClaims), func(_ *jwt.Token) (interface{}, error) {
+		return keys, nil
+	})
+	if err != nil {
+		return false
+	}
+	if !token.Valid {
+		return false
+	}
+	_, ok := token.Claims.(*jwt.RegisteredClaims)
+	return ok
+}
+
+func BenchmarkRS256VerifyRotation(b *testing.B) {
+	// prepare keys
+	keyData, err := ioutil.ReadFile("test/sample_key")
+	if err != nil {
+		b.Fatalf("Unable to load rsa private key from disk: %v", err)
+	}
+	privateKey, err := jwt.ParseRSAPrivateKeyFromPEM(keyData)
+	if err != nil {
+		b.Fatalf("Unable to parse rsa private key: %v", err)
+	}
+
+	keyData, err = ioutil.ReadFile("test/sample_key.pub")
+	if err != nil {
+		b.Fatalf("Unable to load rsa public key from disk: %v", err)
+	}
+	key, err := jwt.ParseRSAPublicKeyFromPEM(keyData)
+	if err != nil {
+		b.Fatalf("Unable to parse rsa public key: %v", err)
+	}
+	wrongKey1, err := jwt.ParseRSAPublicKeyFromPEM([]byte(wrongRSAPubKeyData1))
+	if err != nil {
+		b.Fatalf("Unable to parse wrong rsa public key 1: %v", err)
+	}
+	wrongKey2, err := jwt.ParseRSAPublicKeyFromPEM([]byte(wrongRSAPubKeyData2))
+	if err != nil {
+		b.Fatalf("Unable to parse wrong rsa public key 2: %v", err)
+	}
+	keys := []*rsa.PublicKey{wrongKey1, wrongKey2, key}
+
+	// prepare the payloads
+	now := time.Now()
+	after := jwt.NewNumericDate(now.Add(time.Hour))
+	goodClaim := &jwt.RegisteredClaims{
+		ExpiresAt: after,
+	}
+	before := jwt.NewNumericDate(now.Add(-time.Hour))
+	expiredClaim := &jwt.RegisteredClaims{
+		ExpiresAt: before,
+	}
+
+	goodPayload, err := (&jwt.Token{
+		Raw:    "foo",
+		Method: jwt.SigningMethodRS256,
+		Claims: goodClaim,
+		Header: map[string]interface{}{
+			"alg": "RS256",
+		},
+	}).SignedString(privateKey)
+	if err != nil {
+		b.Fatalf("Unable to sign the good payload: %v", err)
+	}
+
+	expiredPayload, err := (&jwt.Token{
+		Raw:    "foo",
+		Method: jwt.SigningMethodRS256,
+		Claims: expiredClaim,
+		Header: map[string]interface{}{
+			"alg": "RS256",
+		},
+	}).SignedString(privateKey)
+	if err != nil {
+		b.Fatalf("Unable to sign the good payload: %v", err)
+	}
+
+	for _, c := range []struct {
+		label   string
+		payload string
+		valid   bool
+	}{
+		{
+			label:   "good",
+			payload: goodPayload,
+			valid:   true,
+		},
+		{
+			label:   "expired",
+			payload: expiredPayload,
+			valid:   false,
+		},
+	} {
+		b.Run(c.label, func(b *testing.B) {
+			for _, f := range []struct {
+				label string
+				f     func(payload string, keys []*rsa.PublicKey) bool
+			}{
+				{
+					label: "manual",
+					f:     validateWithManualRotation,
+				},
+				{
+					label: "native",
+					f:     validateWithNativeRotation,
+				},
+			} {
+				b.Run(f.label, func(b *testing.B) {
+					b.ReportAllocs()
+
+					got := f.f(c.payload, keys)
+					if got != c.valid {
+						b.Fatalf("got %v, want %v", got, c.valid)
+					}
+
+					b.ResetTimer()
+					b.RunParallel(func(pb *testing.PB) {
+						for pb.Next() {
+							f.f(c.payload, keys)
+						}
+					})
+				})
+			}
+		})
+	}
 }


### PR DESCRIPTION
Add native support for key rotation for ES*, Ed*, HS*, RS*, and PS*
verifications.

In those SigningMethod's Verify implementations, also allow the key to
be the type of the slice of the supported key type, so that the caller
can implement the KeyFunc to return all the accepted keys together to
support key rotation.

While key rotation verification can be done on the callers' side without
this change, this change provides better performance because:

- When trying the next key, the steps before actually using the key do
  not need to be performed again.

- If a verification process failed for non-key reasons (for example,
  because it's already expired), it saves the effort to try the next
  key.

The native key rotation support also helps callers to get more accurate
errors.