### PR TITLE
refactor: make issued at (iat) claim validation optional

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -63,7 +63,7 @@ func (c RegisteredClaims) Valid(opts ...validationOption) error {
 		vErr.Errors |= ValidationErrorExpired
 	}
 
-	if !c.VerifyIssuedAt(now, false) {
+	if !c.VerifyIssuedAt(now, false, opts...) {
 		vErr.Inner = ErrTokenUsedBeforeIssued
 		vErr.Errors |= ValidationErrorIssuedAt
 	}
@@ -89,10 +89,7 @@ func (c *RegisteredClaims) VerifyAudience(cmp string, req bool) bool {
 // VerifyExpiresAt compares the exp claim against cmp (cmp < exp).
 // If req is false, it will return true, if exp is unset.
 func (c *RegisteredClaims) VerifyExpiresAt(cmp time.Time, req bool, opts ...validationOption) bool {
-	validator := validator{}
-	for _, o := range opts {
-		o(&validator)
-	}
+	validator := getValidator(opts...)
 	if c.ExpiresAt == nil {
 		return verifyExp(nil, cmp, req, validator.leeway)
 	}
@@ -102,7 +99,12 @@ func (c *RegisteredClaims) VerifyExpiresAt(cmp time.Time, req bool, opts ...vali
 
 // VerifyIssuedAt compares the iat claim against cmp (cmp >= iat).
 // If req is false, it will return true, if iat is unset.
-func (c *RegisteredClaims) VerifyIssuedAt(cmp time.Time, req bool) bool {
+func (c *RegisteredClaims) VerifyIssuedAt(cmp time.Time, req bool, opts ...validationOption) bool {
+	validator := getValidator(opts...)
+	if !validator.iat {
+		return true
+	}
+
 	if c.IssuedAt == nil {
 		return verifyIat(nil, cmp, req)
 	}
@@ -113,10 +115,7 @@ func (c *RegisteredClaims) VerifyIssuedAt(cmp time.Time, req bool) bool {
 // VerifyNotBefore compares the nbf claim against cmp (cmp >= nbf).
 // If req is false, it will return true, if nbf is unset.
 func (c *RegisteredClaims) VerifyNotBefore(cmp time.Time, req bool, opts ...validationOption) bool {
-	validator := validator{}
-	for _, o := range opts {
-		o(&validator)
-	}
+	validator := getValidator(opts...)
 	if c.NotBefore == nil {
 		return verifyNbf(nil, cmp, req, validator.leeway)
 	}
@@ -164,7 +163,7 @@ func (c StandardClaims) Valid(opts ...validationOption) error {
 		vErr.Errors |= ValidationErrorExpired
 	}
 
-	if !c.VerifyIssuedAt(now, false) {
+	if !c.VerifyIssuedAt(now, false, opts...) {
 		vErr.Inner = ErrTokenUsedBeforeIssued
 		vErr.Errors |= ValidationErrorIssuedAt
 	}
@@ -190,10 +189,7 @@ func (c *StandardClaims) VerifyAudience(cmp string, req bool) bool {
 // VerifyExpiresAt compares the exp claim against cmp (cmp < exp).
 // If req is false, it will return true, if exp is unset.
 func (c *StandardClaims) VerifyExpiresAt(cmp int64, req bool, opts ...validationOption) bool {
-	validator := validator{}
-	for _, o := range opts {
-		o(&validator)
-	}
+	validator := getValidator(opts...)
 	if c.ExpiresAt == 0 {
 		return verifyExp(nil, time.Unix(cmp, 0), req, validator.leeway)
 	}
@@ -204,7 +200,12 @@ func (c *StandardClaims) VerifyExpiresAt(cmp int64, req bool, opts ...validation
 
 // VerifyIssuedAt compares the iat claim against cmp (cmp >= iat).
 // If req is false, it will return true, if iat is unset.
-func (c *StandardClaims) VerifyIssuedAt(cmp int64, req bool) bool {
+func (c *StandardClaims) VerifyIssuedAt(cmp int64, req bool, opts ...validationOption) bool {
+	validator := getValidator(opts...)
+	if !validator.iat {
+		return true
+	}
+
 	if c.IssuedAt == 0 {
 		return verifyIat(nil, time.Unix(cmp, 0), req)
 	}
@@ -216,10 +217,7 @@ func (c *StandardClaims) VerifyIssuedAt(cmp int64, req bool) bool {
 // VerifyNotBefore compares the nbf claim against cmp (cmp >= nbf).
 // If req is false, it will return true, if nbf is unset.
 func (c *StandardClaims) VerifyNotBefore(cmp int64, req bool, opts ...validationOption) bool {
-	validator := validator{}
-	for _, o := range opts {
-		o(&validator)
-	}
+	validator := getValidator(opts...)
 	if c.NotBefore == 0 {
 		return verifyNbf(nil, time.Unix(cmp, 0), req, validator.leeway)
 	}

--- a/map_claims_test.go
+++ b/map_claims_test.go
@@ -70,7 +70,8 @@ func TestMapclaimsVerifyIssuedAtInvalidTypeString(t *testing.T) {
 		"iat": "foo",
 	}
 	want := false
-	got := mapClaims.VerifyIssuedAt(0, false)
+	v := []validationOption{withIssuedAt()}
+	got := mapClaims.VerifyIssuedAt(0, false, v...)
 	if want != got {
 		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
 	}
@@ -110,13 +111,13 @@ func TestMapClaimsVerifyExpiresAtExpire(t *testing.T) {
 		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
 	}
 
-	got = mapClaims.VerifyExpiresAt(exp + 1, true)
+	got = mapClaims.VerifyExpiresAt(exp+1, true)
 	if want != got {
 		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
 	}
 
 	want = true
-	got = mapClaims.VerifyExpiresAt(exp - 1, true)
+	got = mapClaims.VerifyExpiresAt(exp-1, true)
 	if want != got {
 		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
 	}

--- a/parser_option.go
+++ b/parser_option.go
@@ -36,3 +36,10 @@ func WithLeeway(d time.Duration) ParserOption {
 		p.validationOptions = append(p.validationOptions, withLeeway(d))
 	}
 }
+
+// WithIssuedAt is an option to enable the validation of the issued at (iat) claim.
+func WithIssuedAt() ParserOption {
+	return func(p *Parser) {
+		p.validationOptions = append(p.validationOptions, withIssuedAt())
+	}
+}

--- a/validator_option.go
+++ b/validator_option.go
@@ -16,6 +16,7 @@ type validationOption func(*validator)
 // the API is more stable.
 type validator struct {
 	leeway time.Duration // Leeway to provide when validating time values
+	iat    bool
 }
 
 // withLeeway is an option to set the clock skew (leeway) window
@@ -26,4 +27,22 @@ func withLeeway(d time.Duration) validationOption {
 	return func(v *validator) {
 		v.leeway = d
 	}
+}
+
+// withIssuedAth is an option to enable the validation of the issued at (iat) claim
+//
+// Note that this function is (currently) un-exported, its naming is subject to change and will only be exported once
+// the API is more stable.
+func withIssuedAt() validationOption {
+	return func(v *validator) {
+		v.iat = true
+	}
+}
+
+func getValidator(opts ...validationOption) validator {
+	v := validator{}
+	for _, o := range opts {
+		o(&v)
+	}
+	return v
 }


### PR DESCRIPTION
Based on https://datatracker.ietf.org/doc/html/rfc7519/#section-4.1.6 we should not be validating this.

This should permit anyone that wishes to continue to do so.