### PR TITLE
Chore: Added Github Action to auto format code on push to main

### DIFF
--- a/.github/workflows/auto-formatter.yml
+++ b/.github/workflows/auto-formatter.yml
@@ -1,0 +1,21 @@
+name: gofumpt
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  prettier:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.head_ref }}
+        fetch-depth: 0
+
+    - name: Auto Format code
+      uses: iamnotaturtle/auto-gofmt@v2.0.0
+      with:
+        only_changed: true


### PR DESCRIPTION
This PR adds a Github Action to auto-format code using `gofumpt` on push to master.
 
Fixes #93 

Signed-off-by: jay-dee7 <jasdeepsingh.uppal@gmail.com>