### PR TITLE
chore: replace ioutil with io and os

### DIFF
--- a/cmd/jwt/main.go
+++ b/cmd/jwt/main.go
@@ -11,7 +11,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"sort"
@@ -91,7 +90,7 @@ func loadData(p string) ([]byte, error) {
 			return nil, err
 		}
 	}
-	return ioutil.ReadAll(rdr)
+	return io.ReadAll(rdr)
 }
 
 // Print a json object in accordance with the prophecy (or the command line options)

--- a/ecdsa_test.go
+++ b/ecdsa_test.go
@@ -2,7 +2,7 @@ package jwt_test
 
 import (
 	"crypto/ecdsa"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -55,7 +55,7 @@ func TestECDSAVerify(t *testing.T) {
 	for _, data := range ecdsaTestData {
 		var err error
 
-		key, _ := ioutil.ReadFile(data.keys["public"])
+		key, _ := os.ReadFile(data.keys["public"])
 
 		var ecdsaKey *ecdsa.PublicKey
 		if ecdsaKey, err = jwt.ParseECPublicKeyFromPEM(key); err != nil {
@@ -78,7 +78,7 @@ func TestECDSAVerify(t *testing.T) {
 func TestECDSASign(t *testing.T) {
 	for _, data := range ecdsaTestData {
 		var err error
-		key, _ := ioutil.ReadFile(data.keys["private"])
+		key, _ := os.ReadFile(data.keys["private"])
 
 		var ecdsaKey *ecdsa.PrivateKey
 		if ecdsaKey, err = jwt.ParseECPrivateKeyFromPEM(key); err != nil {
@@ -108,7 +108,7 @@ func TestECDSASign(t *testing.T) {
 
 func BenchmarkECDSAParsing(b *testing.B) {
 	for _, data := range ecdsaTestData {
-		key, _ := ioutil.ReadFile(data.keys["private"])
+		key, _ := os.ReadFile(data.keys["private"])
 
 		b.Run(data.name, func(b *testing.B) {
 			b.ReportAllocs()
@@ -126,7 +126,7 @@ func BenchmarkECDSAParsing(b *testing.B) {
 
 func BenchmarkECDSASigning(b *testing.B) {
 	for _, data := range ecdsaTestData {
-		key, _ := ioutil.ReadFile(data.keys["private"])
+		key, _ := os.ReadFile(data.keys["private"])
 
 		ecdsaKey, err := jwt.ParseECPrivateKeyFromPEM(key)
 		if err != nil {

--- a/ed25519_test.go
+++ b/ed25519_test.go
@@ -1,7 +1,7 @@
 package jwt_test
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -38,7 +38,7 @@ func TestEd25519Verify(t *testing.T) {
 	for _, data := range ed25519TestData {
 		var err error
 
-		key, _ := ioutil.ReadFile(data.keys["public"])
+		key, _ := os.ReadFile(data.keys["public"])
 
 		ed25519Key, err := jwt.ParseEdPublicKeyFromPEM(key)
 		if err != nil {
@@ -62,7 +62,7 @@ func TestEd25519Verify(t *testing.T) {
 func TestEd25519Sign(t *testing.T) {
 	for _, data := range ed25519TestData {
 		var err error
-		key, _ := ioutil.ReadFile(data.keys["private"])
+		key, _ := os.ReadFile(data.keys["private"])
 
 		ed25519Key, err := jwt.ParseEdPrivateKeyFromPEM(key)
 		if err != nil {

--- a/hmac_example_test.go
+++ b/hmac_example_test.go
@@ -2,7 +2,7 @@ package jwt_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -15,7 +15,7 @@ var hmacSampleSecret []byte
 
 func init() {
 	// Load sample key data
-	if keyData, e := ioutil.ReadFile("test/hmacTestKey"); e == nil {
+	if keyData, e := os.ReadFile("test/hmacTestKey"); e == nil {
 		hmacSampleSecret = keyData
 	} else {
 		panic(e)

--- a/hmac_test.go
+++ b/hmac_test.go
@@ -1,7 +1,7 @@
 package jwt_test
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -46,7 +46,7 @@ var hmacTestData = []struct {
 }
 
 // Sample data from http://tools.ietf.org/html/draft-jones-json-web-signature-04#appendix-A.1
-var hmacTestKey, _ = ioutil.ReadFile("test/hmacTestKey")
+var hmacTestKey, _ = os.ReadFile("test/hmacTestKey")
 
 func TestHMACVerify(t *testing.T) {
 	for _, data := range hmacTestData {

--- a/http_example_test.go
+++ b/http_example_test.go
@@ -8,11 +8,11 @@ import (
 	"crypto/rsa"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -34,13 +34,13 @@ var (
 
 // read the key files before starting http handlers
 func init() {
-	signBytes, err := ioutil.ReadFile(privKeyPath)
+	signBytes, err := os.ReadFile(privKeyPath)
 	fatal(err)
 
 	signKey, err = jwt.ParseRSAPrivateKeyFromPEM(signBytes)
 	fatal(err)
 
-	verifyBytes, err := ioutil.ReadFile(pubKeyPath)
+	verifyBytes, err := os.ReadFile(pubKeyPath)
 	fatal(err)
 
 	verifyKey, err = jwt.ParseRSAPublicKeyFromPEM(verifyBytes)

--- a/rsa_pss_test.go
+++ b/rsa_pss_test.go
@@ -1,10 +1,11 @@
+//go:build go1.4
 // +build go1.4
 
 package jwt_test
 
 import (
 	"crypto/rsa"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -53,7 +54,7 @@ var rsaPSSTestData = []struct {
 func TestRSAPSSVerify(t *testing.T) {
 	var err error
 
-	key, _ := ioutil.ReadFile("test/sample_key.pub")
+	key, _ := os.ReadFile("test/sample_key.pub")
 	var rsaPSSKey *rsa.PublicKey
 	if rsaPSSKey, err = jwt.ParseRSAPublicKeyFromPEM(key); err != nil {
 		t.Errorf("Unable to parse RSA public key: %v", err)
@@ -76,7 +77,7 @@ func TestRSAPSSVerify(t *testing.T) {
 func TestRSAPSSSign(t *testing.T) {
 	var err error
 
-	key, _ := ioutil.ReadFile("test/sample_key")
+	key, _ := os.ReadFile("test/sample_key")
 	var rsaPSSKey *rsa.PrivateKey
 	if rsaPSSKey, err = jwt.ParseRSAPrivateKeyFromPEM(key); err != nil {
 		t.Errorf("Unable to parse RSA private key: %v", err)

--- a/rsa_test.go
+++ b/rsa_test.go
@@ -1,7 +1,7 @@
 package jwt_test
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -46,7 +46,7 @@ var rsaTestData = []struct {
 }
 
 func TestRSAVerify(t *testing.T) {
-	keyData, _ := ioutil.ReadFile("test/sample_key.pub")
+	keyData, _ := os.ReadFile("test/sample_key.pub")
 	key, _ := jwt.ParseRSAPublicKeyFromPEM(keyData)
 
 	for _, data := range rsaTestData {
@@ -64,7 +64,7 @@ func TestRSAVerify(t *testing.T) {
 }
 
 func TestRSASign(t *testing.T) {
-	keyData, _ := ioutil.ReadFile("test/sample_key")
+	keyData, _ := os.ReadFile("test/sample_key")
 	key, _ := jwt.ParseRSAPrivateKeyFromPEM(keyData)
 
 	for _, data := range rsaTestData {
@@ -83,7 +83,7 @@ func TestRSASign(t *testing.T) {
 }
 
 func TestRSAVerifyWithPreParsedPrivateKey(t *testing.T) {
-	key, _ := ioutil.ReadFile("test/sample_key.pub")
+	key, _ := os.ReadFile("test/sample_key.pub")
 	parsedKey, err := jwt.ParseRSAPublicKeyFromPEM(key)
 	if err != nil {
 		t.Fatal(err)
@@ -97,7 +97,7 @@ func TestRSAVerifyWithPreParsedPrivateKey(t *testing.T) {
 }
 
 func TestRSAWithPreParsedPrivateKey(t *testing.T) {
-	key, _ := ioutil.ReadFile("test/sample_key")
+	key, _ := os.ReadFile("test/sample_key")
 	parsedKey, err := jwt.ParseRSAPrivateKeyFromPEM(key)
 	if err != nil {
 		t.Fatal(err)
@@ -114,9 +114,9 @@ func TestRSAWithPreParsedPrivateKey(t *testing.T) {
 }
 
 func TestRSAKeyParsing(t *testing.T) {
-	key, _ := ioutil.ReadFile("test/sample_key")
-	secureKey, _ := ioutil.ReadFile("test/privateSecure.pem")
-	pubKey, _ := ioutil.ReadFile("test/sample_key.pub")
+	key, _ := os.ReadFile("test/sample_key")
+	secureKey, _ := os.ReadFile("test/privateSecure.pem")
+	pubKey, _ := os.ReadFile("test/sample_key.pub")
 	badKey := []byte("All your base are belong to key")
 
 	// Test parsePrivateKey
@@ -156,7 +156,7 @@ func TestRSAKeyParsing(t *testing.T) {
 }
 
 func BenchmarkRSAParsing(b *testing.B) {
-	key, _ := ioutil.ReadFile("test/sample_key")
+	key, _ := os.ReadFile("test/sample_key")
 
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -170,7 +170,7 @@ func BenchmarkRSAParsing(b *testing.B) {
 }
 
 func BenchmarkRS256Signing(b *testing.B) {
-	key, _ := ioutil.ReadFile("test/sample_key")
+	key, _ := os.ReadFile("test/sample_key")
 	parsedKey, err := jwt.ParseRSAPrivateKeyFromPEM(key)
 	if err != nil {
 		b.Fatal(err)
@@ -180,7 +180,7 @@ func BenchmarkRS256Signing(b *testing.B) {
 }
 
 func BenchmarkRS384Signing(b *testing.B) {
-	key, _ := ioutil.ReadFile("test/sample_key")
+	key, _ := os.ReadFile("test/sample_key")
 	parsedKey, err := jwt.ParseRSAPrivateKeyFromPEM(key)
 	if err != nil {
 		b.Fatal(err)
@@ -190,7 +190,7 @@ func BenchmarkRS384Signing(b *testing.B) {
 }
 
 func BenchmarkRS512Signing(b *testing.B) {
-	key, _ := ioutil.ReadFile("test/sample_key")
+	key, _ := os.ReadFile("test/sample_key")
 	parsedKey, err := jwt.ParseRSAPrivateKeyFromPEM(key)
 	if err != nil {
 		b.Fatal(err)

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -3,13 +3,13 @@ package test
 import (
 	"crypto"
 	"crypto/rsa"
-	"io/ioutil"
+	"os"
 
 	"github.com/golang-jwt/jwt/v4"
 )
 
 func LoadRSAPrivateKeyFromDisk(location string) *rsa.PrivateKey {
-	keyData, e := ioutil.ReadFile(location)
+	keyData, e := os.ReadFile(location)
 	if e != nil {
 		panic(e.Error())
 	}
@@ -21,7 +21,7 @@ func LoadRSAPrivateKeyFromDisk(location string) *rsa.PrivateKey {
 }
 
 func LoadRSAPublicKeyFromDisk(location string) *rsa.PublicKey {
-	keyData, e := ioutil.ReadFile(location)
+	keyData, e := os.ReadFile(location)
 	if e != nil {
 		panic(e.Error())
 	}
@@ -45,7 +45,7 @@ func MakeSampleToken(c jwt.Claims, method jwt.SigningMethod, key interface{}) st
 }
 
 func LoadECPrivateKeyFromDisk(location string) crypto.PrivateKey {
-	keyData, e := ioutil.ReadFile(location)
+	keyData, e := os.ReadFile(location)
 	if e != nil {
 		panic(e.Error())
 	}
@@ -57,7 +57,7 @@ func LoadECPrivateKeyFromDisk(location string) crypto.PrivateKey {
 }
 
 func LoadECPublicKeyFromDisk(location string) crypto.PublicKey {
-	keyData, e := ioutil.ReadFile(location)
+	keyData, e := os.ReadFile(location)
 	if e != nil {
 		panic(e.Error())
 	}


### PR DESCRIPTION
`ioutil` was deprecated in [Go 1.16](https://go.dev/doc/go1.16)