### PR TITLE
Fixed integer overflow in NumericDate.MarshalJSON

### DIFF
--- a/types.go
+++ b/types.go
@@ -58,11 +58,12 @@ func (date NumericDate) MarshalJSON() (b []byte, err error) {
 	// For very large timestamps, UnixNano would overflow an int64, but this
 	// function requires nanosecond level precision, so we have to use the
 	// following technique to get round the issue:
-	// 1. Take the normal unix timestamp to form the seconds number part,
+	// 1. Take the normal unix timestamp to form the whole number part of the
+	//    output,
 	// 2. Take the result of the Nanosecond function, which retuns the offset
 	//    within the second of the particular unix time instance, to form the
-	//    decimal part of the result
-	// 3. Concatenate the seconds and the decimal part to produce the final result
+	//    decimal part of the output
+	// 3. Concatenate them to produce the final result
 	seconds := strconv.FormatInt(truncatedDate.Unix(), 10)
 	nanosecondsOffset := strconv.FormatFloat(float64(truncatedDate.Nanosecond())/float64(time.Second), 'f', prec, 64)
 

--- a/types.go
+++ b/types.go
@@ -53,7 +53,8 @@ func (date NumericDate) MarshalJSON() (b []byte, err error) {
 	if TimePrecision < time.Second {
 		prec = int(math.Log10(float64(time.Second) / float64(TimePrecision)))
 	}
-	f := float64(date.Truncate(TimePrecision).UnixNano()) / float64(time.Second)
+	trancatedDate := date.Truncate(TimePrecision)
+	f := float64(trancatedDate.Unix()) + float64(trancatedDate.Nanosecond()) / float64(time.Second)
 
 	return []byte(strconv.FormatFloat(f, 'f', prec, 64)), nil
 }

--- a/types.go
+++ b/types.go
@@ -54,9 +54,11 @@ func (date NumericDate) MarshalJSON() (b []byte, err error) {
 		prec = int(math.Log10(float64(time.Second) / float64(TimePrecision)))
 	}
 	trancatedDate := date.Truncate(TimePrecision)
-	f := float64(trancatedDate.Unix()) + float64(trancatedDate.Nanosecond()) / float64(time.Second)
+	whole := strconv.FormatInt(trancatedDate.Unix(), 10)
+	decimal := strconv.FormatFloat(float64(trancatedDate.Nanosecond())/float64(time.Second), 'f', prec, 64)
+	f := append([]byte(whole), []byte(decimal)[1:]...)
 
-	return []byte(strconv.FormatFloat(f, 'f', prec, 64)), nil
+	return f, nil
 }
 
 // UnmarshalJSON is an implementation of the json.RawMessage interface and deserializses a

--- a/types_test.go
+++ b/types_test.go
@@ -79,13 +79,18 @@ func TestNumericDate_MarshalJSON(t *testing.T) {
 	}{
 		{time.Unix(5243700879, 0), "5243700879", time.Second},
 		{time.Unix(5243700879, 0), "5243700879.000", time.Millisecond},
-		{time.Unix(5243700879, 0), "5243700879.000001", time.Microsecond},
-		{time.Unix(5243700879, 0), "5243700879.000000954", time.Nanosecond},
+		{time.Unix(5243700879, 0), "5243700879.000000", time.Microsecond},
+		{time.Unix(5243700879, 0), "5243700879.000000000", time.Nanosecond},
 		//
 		{time.Unix(4239425898, 0), "4239425898", time.Second},
 		{time.Unix(4239425898, 0), "4239425898.000", time.Millisecond},
 		{time.Unix(4239425898, 0), "4239425898.000000", time.Microsecond},
 		{time.Unix(4239425898, 0), "4239425898.000000000", time.Nanosecond},
+		//
+		{time.Unix(253402271999, 0), "253402271999", time.Second},
+		{time.Unix(253402271999, 0), "253402271999.000", time.Millisecond},
+		{time.Unix(253402271999, 0), "253402271999.000000", time.Microsecond},
+		{time.Unix(253402271999, 0), "253402271999.000000000", time.Nanosecond},
 		//
 		{time.Unix(0, 1644285000210402000), "1644285000", time.Second},
 		{time.Unix(0, 1644285000210402000), "1644285000.210", time.Millisecond},

--- a/types_test.go
+++ b/types_test.go
@@ -2,6 +2,7 @@ package jwt_test
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 	"time"
 
@@ -95,12 +96,22 @@ func TestNumericDate_MarshalJSON(t *testing.T) {
 		{time.Unix(0, 1644285000210402000), "1644285000", time.Second},
 		{time.Unix(0, 1644285000210402000), "1644285000.210", time.Millisecond},
 		{time.Unix(0, 1644285000210402000), "1644285000.210402", time.Microsecond},
-		{time.Unix(0, 1644285000210402000), "1644285000.210402012", time.Nanosecond},
+		{time.Unix(0, 1644285000210402000), "1644285000.210402000", time.Nanosecond},
 		//
 		{time.Unix(0, 1644285315063096000), "1644285315", time.Second},
 		{time.Unix(0, 1644285315063096000), "1644285315.063", time.Millisecond},
 		{time.Unix(0, 1644285315063096000), "1644285315.063096", time.Microsecond},
-		{time.Unix(0, 1644285315063096000), "1644285315.063096046", time.Nanosecond},
+		{time.Unix(0, 1644285315063096000), "1644285315.063096000", time.Nanosecond},
+		// Maximum time that a go time.Time can represent
+		{time.Unix(math.MaxInt64, 999999999), "9223372036854775807", time.Second},
+		{time.Unix(math.MaxInt64, 999999999), "9223372036854775807.999", time.Millisecond},
+		{time.Unix(math.MaxInt64, 999999999), "9223372036854775807.999999", time.Microsecond},
+		{time.Unix(math.MaxInt64, 999999999), "9223372036854775807.999999999", time.Nanosecond},
+		// Strange precisions
+		{time.Unix(math.MaxInt64, 999999999), "9223372036854775807", time.Second},
+		{time.Unix(math.MaxInt64, 999999999), "9223372036854775756", time.Minute},
+		{time.Unix(math.MaxInt64, 999999999), "9223372036854774016", time.Hour},
+		{time.Unix(math.MaxInt64, 999999999), "9223372036854745216", 24 * time.Hour},
 	}
 
 	for i, tc := range tt {


### PR DESCRIPTION
Fixed #199 

The original issue was caused by the fact that if we use a very large
unix timestamp. The resulting value from `Time.UnixNano()`
overflows a int64, as documented here: https://pkg.go.dev/time#Time.UnixNano.

This patch works around the issue by treating the second part and
nanosecond part separately, taking the second part from `Time.Unix()`,
and the nanosecond part from `Time.Nanosecond()`, formatting them
separately, and then combining the resulting strings.

This approach allows us to correctly marshal all go `time.Time` instances,
whereas using `Time.Unix` won't give us enough precision, and either
`Time.UnixMicro` or `Time.UnixNano` would overflow at some point for
even valid `time.Time` instances.

The added benefit of this approach is that we no longer have to deal
with the added nanosecond delta that Go uses in order to achieve
monotonic time, so the result of marshaling `time.Unix(0, 123456)` will
simply be `0.123456` instead of `0.123456 + small_delta`.