### PR TITLE
Validation Options - Experiment 1: Embedding validation options in claim

### DIFF
--- a/map_claims.go
+++ b/map_claims.go
@@ -45,14 +45,14 @@ func (m MapClaims) VerifyExpiresAt(cmp int64, req bool) bool {
 	switch exp := v.(type) {
 	case float64:
 		if exp == 0 {
-			return verifyExp(nil, cmpTime, req)
+			return verifyExp(nil, cmpTime, req, 0)
 		}
 
-		return verifyExp(&newNumericDateFromSeconds(exp).Time, cmpTime, req)
+		return verifyExp(&newNumericDateFromSeconds(exp).Time, cmpTime, req, 0)
 	case json.Number:
 		v, _ := exp.Float64()
 
-		return verifyExp(&newNumericDateFromSeconds(v).Time, cmpTime, req)
+		return verifyExp(&newNumericDateFromSeconds(v).Time, cmpTime, req, 0)
 	}
 
 	return false
@@ -97,14 +97,14 @@ func (m MapClaims) VerifyNotBefore(cmp int64, req bool) bool {
 	switch nbf := v.(type) {
 	case float64:
 		if nbf == 0 {
-			return verifyNbf(nil, cmpTime, req)
+			return verifyNbf(nil, cmpTime, req, 0)
 		}
 
-		return verifyNbf(&newNumericDateFromSeconds(nbf).Time, cmpTime, req)
+		return verifyNbf(&newNumericDateFromSeconds(nbf).Time, cmpTime, req, 0)
 	case json.Number:
 		v, _ := nbf.Float64()
 
-		return verifyNbf(&newNumericDateFromSeconds(v).Time, cmpTime, req)
+		return verifyNbf(&newNumericDateFromSeconds(v).Time, cmpTime, req, 0)
 	}
 
 	return false

--- a/parser.go
+++ b/parser.go
@@ -22,6 +22,8 @@ type Parser struct {
 	//
 	// Deprecated: In future releases, this field will not be exported anymore and should be set with an option to NewParser instead.
 	SkipClaimsValidation bool
+
+	v validator
 }
 
 // NewParser creates a new Parser with the specified options
@@ -79,6 +81,18 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
 	}
 
 	vErr := &ValidationError{}
+
+	// Experimental: inject the validation options of the parser into the
+	// claims. This provides a backwards compatible way to have validation
+	// options, but it unfortunately only works for jwt.RegisteredClaims and
+	// jwt.StandardClaims
+	if rclaims, ok := claims.(*RegisteredClaims); ok {
+		rclaims.v = p.v
+	}
+
+	if sclaims, ok := claims.(*StandardClaims); ok {
+		sclaims.v = p.v
+	}
 
 	// Validate Claims
 	if !p.SkipClaimsValidation {

--- a/parser_option.go
+++ b/parser_option.go
@@ -1,5 +1,7 @@
 package jwt
 
+import "time"
+
 // ParserOption is used to implement functional-style options that modify the behavior of the parser. To add
 // new options, just create a function (ideally beginning with With or Without) that returns an anonymous function that
 // takes a *Parser type as input and manipulates its configuration accordingly.
@@ -25,5 +27,12 @@ func WithJSONNumber() ParserOption {
 func WithoutClaimsValidation() ParserOption {
 	return func(p *Parser) {
 		p.SkipClaimsValidation = true
+	}
+}
+
+// WithLeeway returns the ParserOption for specifying the leeway window.
+func WithLeeway(d time.Duration) ParserOption {
+	return func(p *Parser) {
+		p.v.leeway = d
 	}
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -321,6 +321,19 @@ var jwtTestData = []struct {
 		&jwt.Parser{UseJSONNumber: true},
 		jwt.SigningMethodRS256,
 	},
+	{
+		"RFC7519 Claims - expired by 100s with 120s skew",
+		"", // autogen
+		defaultKeyFunc,
+		&jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Second * 100)),
+		},
+		true,
+		0,
+		nil,
+		jwt.NewParser(jwt.WithLeeway(2 * time.Minute)),
+		jwt.SigningMethodRS256,
+	},
 }
 
 // signToken creates and returns a signed JWT token using signingMethod.

--- a/validation_options.go
+++ b/validation_options.go
@@ -1,0 +1,9 @@
+package jwt
+
+import "time"
+
+// validator is magic
+type validator struct {
+	// Leeway to provide to the current time when validating time values
+	leeway time.Duration
+}


### PR DESCRIPTION
This PR is part of a series of experiments, to see which options we have to implement validation options in a backwards compatible way. I want to get a fell about our options first and some feedback from the community, before we implement all desired options. I am looking to gather feedback here: https://github.com/golang-jwt/jwt/discussions/211

Option 1 is to embedded a `validator` struct which olds all the necessary information into the claims itself. It is populated by the Parser during `Parse`. The claim's `Valid` function can then retrieve the information and adjust the validation.

Pros:
* Keeps everything as is on the outside, no changes to the exported `Valid` or `VerifyXXX` functions, not even with varargs.
* Pretty simple to use for the user I guess
* The variable is unexported in the claims itself (`v`) and should therefore not interfere with json Marshalling

Cons:
* can only work with `jwt.RegisteredClaims` (and jwt.StandardClaims) because I have no way to "silently" inject it into `MapClaims`. I could add a key to the map, but this will be then transparent to the user and might conflict with a custom claim the user has
*  The way the current test is structured in `parser_test.go` I cannot really test it because it is using the `jwt_test` package for tests and therefore cannot access the unexpected `v` field and this leads to some errors in the comparison test.