### PR TITLE
Validation Options - Experiment 2: New approach using external `Validator` struct

### DIFF
--- a/map_claims.go
+++ b/map_claims.go
@@ -45,14 +45,14 @@ func (m MapClaims) VerifyExpiresAt(cmp int64, req bool) bool {
 	switch exp := v.(type) {
 	case float64:
 		if exp == 0 {
-			return verifyExp(nil, cmpTime, req)
+			return verifyExp(nil, cmpTime, req, 0)
 		}
 
-		return verifyExp(&newNumericDateFromSeconds(exp).Time, cmpTime, req)
+		return verifyExp(&newNumericDateFromSeconds(exp).Time, cmpTime, req, 0)
 	case json.Number:
 		v, _ := exp.Float64()
 
-		return verifyExp(&newNumericDateFromSeconds(v).Time, cmpTime, req)
+		return verifyExp(&newNumericDateFromSeconds(v).Time, cmpTime, req, 0)
 	}
 
 	return false
@@ -71,14 +71,14 @@ func (m MapClaims) VerifyIssuedAt(cmp int64, req bool) bool {
 	switch iat := v.(type) {
 	case float64:
 		if iat == 0 {
-			return verifyIat(nil, cmpTime, req)
+			return verifyIat(nil, cmpTime, req, 0)
 		}
 
-		return verifyIat(&newNumericDateFromSeconds(iat).Time, cmpTime, req)
+		return verifyIat(&newNumericDateFromSeconds(iat).Time, cmpTime, req, 0)
 	case json.Number:
 		v, _ := iat.Float64()
 
-		return verifyIat(&newNumericDateFromSeconds(v).Time, cmpTime, req)
+		return verifyIat(&newNumericDateFromSeconds(v).Time, cmpTime, req, 0)
 	}
 
 	return false
@@ -97,14 +97,14 @@ func (m MapClaims) VerifyNotBefore(cmp int64, req bool) bool {
 	switch nbf := v.(type) {
 	case float64:
 		if nbf == 0 {
-			return verifyNbf(nil, cmpTime, req)
+			return verifyNbf(nil, cmpTime, req, 0)
 		}
 
-		return verifyNbf(&newNumericDateFromSeconds(nbf).Time, cmpTime, req)
+		return verifyNbf(&newNumericDateFromSeconds(nbf).Time, cmpTime, req, 0)
 	case json.Number:
 		v, _ := nbf.Float64()
 
-		return verifyNbf(&newNumericDateFromSeconds(v).Time, cmpTime, req)
+		return verifyNbf(&newNumericDateFromSeconds(v).Time, cmpTime, req, 0)
 	}
 
 	return false

--- a/parser_option.go
+++ b/parser_option.go
@@ -27,3 +27,9 @@ func WithoutClaimsValidation() ParserOption {
 		p.SkipClaimsValidation = true
 	}
 }
+
+func WithValidator(v *Validator) ParserOption {
+	return func(p *Parser) {
+		p.validator = v
+	}
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -3,7 +3,6 @@ package jwt_test
 import (
 	"crypto"
 	"crypto/rsa"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -56,7 +55,7 @@ var jwtTestData = []struct {
 	parser        *jwt.Parser
 	signingMethod jwt.SigningMethod // The method to sign the JWT token for test purpose
 }{
-	{
+	/*{
 		"basic",
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.FhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
 		defaultKeyFunc,
@@ -321,6 +320,28 @@ var jwtTestData = []struct {
 		&jwt.Parser{UseJSONNumber: true},
 		jwt.SigningMethodRS256,
 	},
+	{
+		"RFC7519 Claims - nbf with 60s skew",
+		"", // autogen
+		defaultKeyFunc,
+		&jwt.RegisteredClaims{NotBefore: jwt.NewNumericDate(time.Now().Add(time.Second * 100))},
+		false,
+		jwt.ValidationErrorNotValidYet,
+		[]error{jwt.ErrTokenNotValidYet},
+		jwt.NewParser(jwt.WithValidator(jwt.NewValidator(jwt.WithLeeway(time.Minute)))),
+		jwt.SigningMethodRS256,
+	},*/
+	{
+		"RFC7519 Claims - nbf with 120s skew",
+		"", // autogen
+		defaultKeyFunc,
+		&jwt.RegisteredClaims{NotBefore: jwt.NewNumericDate(time.Now().Add(time.Second * 100))},
+		true,
+		0,
+		nil,
+		jwt.NewParser(jwt.WithValidator(jwt.NewValidator(jwt.WithLeeway(2 * time.Minute)))),
+		jwt.SigningMethodRS256,
+	},
 }
 
 // signToken creates and returns a signed JWT token using signingMethod.
@@ -354,7 +375,7 @@ func TestParser_Parse(t *testing.T) {
 			var err error
 			var parser = data.parser
 			if parser == nil {
-				parser = new(jwt.Parser)
+				parser = jwt.NewParser()
 			}
 			// Figure out correct claims type
 			switch data.claims.(type) {

--- a/validator.go
+++ b/validator.go
@@ -1,0 +1,164 @@
+package jwt
+
+import (
+	"crypto/subtle"
+	"fmt"
+	"time"
+)
+
+type Validator struct {
+	leeway time.Duration
+}
+
+type ClaimsV2 interface {
+	GetExpiryAt() *NumericDate
+	GetIssuedAt() *NumericDate
+	GetNotBefore() *NumericDate
+	GetIssuer() string
+	GetAudience() ClaimStrings
+}
+
+func (v *Validator) Validate(claims ClaimsV2) error {
+	vErr := new(ValidationError)
+	now := TimeFunc()
+
+	if !v.VerifyExpiresAt(claims, now, false) {
+		exp := claims.GetExpiryAt()
+		delta := now.Sub(exp.Time)
+		vErr.Inner = fmt.Errorf("%s by %s", ErrTokenExpired, delta)
+		vErr.Errors |= ValidationErrorExpired
+	}
+
+	if !v.VerifyIssuedAt(claims, now, false) {
+		vErr.Inner = ErrTokenUsedBeforeIssued
+		vErr.Errors |= ValidationErrorIssuedAt
+	}
+
+	if !v.VerifyNotBefore(claims, now, false) {
+		vErr.Inner = ErrTokenNotValidYet
+		vErr.Errors |= ValidationErrorNotValidYet
+	}
+
+	if vErr.valid() {
+		return nil
+	}
+
+	return vErr
+}
+
+// VerifyAudience compares the aud claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (v *Validator) VerifyAudience(claims ClaimsV2, cmp string, req bool) bool {
+	return verifyAud(claims.GetAudience(), cmp, req)
+}
+
+// VerifyExpiresAt compares the exp claim against cmp (cmp < exp).
+// If req is false, it will return true, if exp is unset.
+func (v *Validator) VerifyExpiresAt(claims ClaimsV2, cmp time.Time, req bool) bool {
+	exp := claims.GetExpiryAt()
+	if exp == nil {
+		return verifyExp(nil, cmp, req, v.leeway)
+	}
+
+	return verifyExp(&exp.Time, cmp, req, v.leeway)
+}
+
+// VerifyIssuedAt compares the iat claim against cmp (cmp >= iat).
+// If req is false, it will return true, if iat is unset.
+func (v *Validator) VerifyIssuedAt(claims ClaimsV2, cmp time.Time, req bool) bool {
+	iat := claims.GetIssuedAt()
+	if iat == nil {
+		return verifyIat(nil, cmp, req, v.leeway)
+	}
+
+	return verifyIat(&iat.Time, cmp, req, v.leeway)
+}
+
+// VerifyNotBefore compares the nbf claim against cmp (cmp >= nbf).
+// If req is false, it will return true, if nbf is unset.
+func (v *Validator) VerifyNotBefore(claims ClaimsV2, cmp time.Time, req bool) bool {
+	nbf := claims.GetNotBefore()
+	if nbf == nil {
+		return verifyNbf(nil, cmp, req, v.leeway)
+	}
+
+	return verifyNbf(&nbf.Time, cmp, req, v.leeway)
+}
+
+// VerifyIssuer compares the iss claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (v *Validator) VerifyIssuer(claims ClaimsV2, cmp string, req bool) bool {
+	return verifyIss(claims.GetIssuer(), cmp, req)
+}
+
+func NewValidator(opts ...ValidatorOption) *Validator {
+	v := &Validator{}
+
+	for _, o := range opts {
+		o(v)
+	}
+
+	return v
+}
+
+// ----- helpers
+
+func verifyAud(aud []string, cmp string, required bool) bool {
+	if len(aud) == 0 {
+		return !required
+	}
+	// use a var here to keep constant time compare when looping over a number of claims
+	result := false
+
+	var stringClaims string
+	for _, a := range aud {
+		if subtle.ConstantTimeCompare([]byte(a), []byte(cmp)) != 0 {
+			result = true
+		}
+		stringClaims = stringClaims + a
+	}
+
+	// case where "" is sent in one or many aud claims
+	if len(stringClaims) == 0 {
+		return !required
+	}
+
+	return result
+}
+
+func verifyExp(exp *time.Time, now time.Time, required bool, skew time.Duration) bool {
+	if exp == nil {
+		return !required
+	}
+
+	return now.Before((*exp).Add(+skew))
+}
+
+func verifyIat(iat *time.Time, now time.Time, required bool, skew time.Duration) bool {
+	if iat == nil {
+		return !required
+	}
+
+	t := (*iat).Add(-skew)
+	return now.After(t) || now.Equal(t)
+}
+
+func verifyNbf(nbf *time.Time, now time.Time, required bool, skew time.Duration) bool {
+	if nbf == nil {
+		return !required
+	}
+
+	t := (*nbf).Add(-skew)
+	return now.After(t) || now.Equal(t)
+}
+
+func verifyIss(iss string, cmp string, required bool) bool {
+	if iss == "" {
+		return !required
+	}
+	if subtle.ConstantTimeCompare([]byte(iss), []byte(cmp)) != 0 {
+		return true
+	} else {
+		return false
+	}
+}

--- a/validator_option.go
+++ b/validator_option.go
@@ -1,0 +1,17 @@
+package jwt
+
+import "time"
+
+// ValidatorOption is used to implement functional-style options that modify the
+// behavior of the validator. To add new options, just create a function
+// (ideally beginning with With or Without) that returns an anonymous function
+// that takes a *Parser type as input and manipulates its configuration
+// accordingly.
+type ValidatorOption func(*Validator)
+
+// WithLeeway returns the ParserOption for specifying the leeway window.
+func WithLeeway(leeway time.Duration) ValidatorOption {
+	return func(v *Validator) {
+		v.leeway = leeway
+	}
+}


### PR DESCRIPTION
This PR is part of a series of experiments, to see which options we have to implement validation options in a backwards compatible way. I want to get a fell about our options first and some feedback from the community, before we implement all desired options. I am looking to gather feedback here: https://github.com/golang-jwt/jwt/discussions/211

Option 2 is creating a completely new struct, called `Validator`, which takes care of the actual validation. A validator takes certain options (using functional options), such as leeway, etc. and can be passed to a `Parser` If none is specified, the default `NewValidator()` is used.

Pros:
* New API gives us the option to "clean" the validation up from the start and design it the way we want it, potentially moving towards this new API in v5 and sort of making it "optional" in v4.
* It separates the validation logic from the actual claim, also removing some of the duplicated code from the claims.go file

Cons:
* We need a new interface (`ClaimsV2` for now, can also be unexported probably) that is used to retrieve the needed values for validation (exp, nbf, etc.) to the validator. Currently, only `jwt.RegisteredClaims` implements this new interface. `ParseWithClaims` checks for the existence of this interface, if it does not exist, the old way of validating is used
* There is a slight problem with the `Valid()` function of a claim. As long as the default validator without any options is used, it is fine. However, if a validator with options, e.g. is passed to the `Parser`, this validator is used inside `ParseWithClaims` and it is also used to set the `token.Valid` flag, which should be the canonical way to check, if the token is valid. However, if the user calls `Valid()` on the claim, this will not take the validator with the options but the default one (because we have no way to supply the validator to the claim in this PR). Therefore, we should probably deprecate `Valid()` and make a strong hint, that it should not be used, if used with validation options.