### PR TITLE
Validation Options - Experiment 3 : Introducing new (optional) `ClaimsWithOptions` interface next to `Claims`

### DIFF
--- a/map_claims.go
+++ b/map_claims.go
@@ -11,6 +11,10 @@ import (
 // This is the default claims type if you don't supply one
 type MapClaims map[string]interface{}
 
+func (m MapClaims) Valid() error {
+	return m.ValidWithOptions()
+}
+
 // VerifyAudience Compares the aud claim against cmp.
 // If required is false, this method will return true if the value matches or is unset
 func (m MapClaims) VerifyAudience(cmp string, req bool) bool {
@@ -34,7 +38,7 @@ func (m MapClaims) VerifyAudience(cmp string, req bool) bool {
 
 // VerifyExpiresAt compares the exp claim against cmp (cmp <= exp).
 // If req is false, it will return true, if exp is unset.
-func (m MapClaims) VerifyExpiresAt(cmp int64, req bool) bool {
+func (m MapClaims) VerifyExpiresAt(cmp int64, req bool, opts ...validationOption) bool {
 	cmpTime := time.Unix(cmp, 0)
 
 	v, ok := m["exp"]
@@ -42,17 +46,22 @@ func (m MapClaims) VerifyExpiresAt(cmp int64, req bool) bool {
 		return !req
 	}
 
+	validator := validator{}
+	for _, o := range opts {
+		o(&validator)
+	}
+
 	switch exp := v.(type) {
 	case float64:
 		if exp == 0 {
-			return verifyExp(nil, cmpTime, req)
+			return verifyExp(nil, cmpTime, req, validator.leeway)
 		}
 
-		return verifyExp(&newNumericDateFromSeconds(exp).Time, cmpTime, req)
+		return verifyExp(&newNumericDateFromSeconds(exp).Time, cmpTime, req, validator.leeway)
 	case json.Number:
 		v, _ := exp.Float64()
 
-		return verifyExp(&newNumericDateFromSeconds(v).Time, cmpTime, req)
+		return verifyExp(&newNumericDateFromSeconds(v).Time, cmpTime, req, validator.leeway)
 	}
 
 	return false
@@ -86,7 +95,7 @@ func (m MapClaims) VerifyIssuedAt(cmp int64, req bool) bool {
 
 // VerifyNotBefore compares the nbf claim against cmp (cmp >= nbf).
 // If req is false, it will return true, if nbf is unset.
-func (m MapClaims) VerifyNotBefore(cmp int64, req bool) bool {
+func (m MapClaims) VerifyNotBefore(cmp int64, req bool, opts ...validationOption) bool {
 	cmpTime := time.Unix(cmp, 0)
 
 	v, ok := m["nbf"]
@@ -94,17 +103,22 @@ func (m MapClaims) VerifyNotBefore(cmp int64, req bool) bool {
 		return !req
 	}
 
+	validator := validator{}
+	for _, o := range opts {
+		o(&validator)
+	}
+
 	switch nbf := v.(type) {
 	case float64:
 		if nbf == 0 {
-			return verifyNbf(nil, cmpTime, req)
+			return verifyNbf(nil, cmpTime, req, validator.leeway)
 		}
 
-		return verifyNbf(&newNumericDateFromSeconds(nbf).Time, cmpTime, req)
+		return verifyNbf(&newNumericDateFromSeconds(nbf).Time, cmpTime, req, validator.leeway)
 	case json.Number:
 		v, _ := nbf.Float64()
 
-		return verifyNbf(&newNumericDateFromSeconds(v).Time, cmpTime, req)
+		return verifyNbf(&newNumericDateFromSeconds(v).Time, cmpTime, req, validator.leeway)
 	}
 
 	return false
@@ -121,11 +135,11 @@ func (m MapClaims) VerifyIssuer(cmp string, req bool) bool {
 // There is no accounting for clock skew.
 // As well, if any of the above claims are not in the token, it will still
 // be considered a valid claim.
-func (m MapClaims) Valid() error {
+func (m MapClaims) ValidWithOptions(opts ...validationOption) error {
 	vErr := new(ValidationError)
 	now := TimeFunc().Unix()
 
-	if !m.VerifyExpiresAt(now, false) {
+	if !m.VerifyExpiresAt(now, false, opts...) {
 		// TODO(oxisto): this should be replaced with ErrTokenExpired
 		vErr.Inner = errors.New("Token is expired")
 		vErr.Errors |= ValidationErrorExpired
@@ -137,7 +151,7 @@ func (m MapClaims) Valid() error {
 		vErr.Errors |= ValidationErrorIssuedAt
 	}
 
-	if !m.VerifyNotBefore(now, false) {
+	if !m.VerifyNotBefore(now, false, opts...) {
 		// TODO(oxisto): this should be replaced with ErrTokenNotValidYet
 		vErr.Inner = errors.New("Token is not valid yet")
 		vErr.Errors |= ValidationErrorNotValidYet

--- a/parser.go
+++ b/parser.go
@@ -22,6 +22,8 @@ type Parser struct {
 	//
 	// Deprecated: In future releases, this field will not be exported anymore and should be set with an option to NewParser instead.
 	SkipClaimsValidation bool
+
+	validationOptions []validationOption
 }
 
 // NewParser creates a new Parser with the specified options
@@ -82,14 +84,25 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
 
 	// Validate Claims
 	if !p.SkipClaimsValidation {
-		if err := token.Claims.Valid(); err != nil {
-
-			// If the Claims Valid returned an error, check if it is a validation error,
-			// If it was another error type, create a ValidationError with a generic ClaimsInvalid flag set
-			if e, ok := err.(*ValidationError); !ok {
-				vErr = &ValidationError{Inner: err, Errors: ValidationErrorClaimsInvalid}
-			} else {
-				vErr = e
+		if cwo, ok := token.Claims.(ClaimsWithOptions); ok {
+			if err := cwo.ValidWithOptions(p.validationOptions...); err != nil {
+				// If the Claims Valid returned an error, check if it is a validation error,
+				// If it was another error type, create a ValidationError with a generic ClaimsInvalid flag set
+				if e, ok := err.(*ValidationError); !ok {
+					vErr = &ValidationError{Inner: err, Errors: ValidationErrorClaimsInvalid}
+				} else {
+					vErr = e
+				}
+			}
+		} else {
+			if err := token.Claims.Valid(); err != nil {
+				// If the Claims Valid returned an error, check if it is a validation error,
+				// If it was another error type, create a ValidationError with a generic ClaimsInvalid flag set
+				if e, ok := err.(*ValidationError); !ok {
+					vErr = &ValidationError{Inner: err, Errors: ValidationErrorClaimsInvalid}
+				} else {
+					vErr = e
+				}
 			}
 		}
 	}

--- a/parser_option.go
+++ b/parser_option.go
@@ -1,5 +1,7 @@
 package jwt
 
+import "time"
+
 // ParserOption is used to implement functional-style options that modify the behavior of the parser. To add
 // new options, just create a function (ideally beginning with With or Without) that returns an anonymous function that
 // takes a *Parser type as input and manipulates its configuration accordingly.
@@ -25,5 +27,12 @@ func WithJSONNumber() ParserOption {
 func WithoutClaimsValidation() ParserOption {
 	return func(p *Parser) {
 		p.SkipClaimsValidation = true
+	}
+}
+
+// WithLeeway returns the ParserOption for specifying the leeway window.
+func WithLeeway(d time.Duration) ParserOption {
+	return func(p *Parser) {
+		p.validationOptions = append(p.validationOptions, withLeeway(d))
 	}
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -79,6 +79,28 @@ var jwtTestData = []struct {
 		jwt.SigningMethodRS256,
 	},
 	{
+		"basic expired with 60s skew",
+		"", // autogen
+		defaultKeyFunc,
+		jwt.MapClaims{"foo": "bar", "exp": float64(time.Now().Unix() - 100)},
+		false,
+		jwt.ValidationErrorExpired,
+		[]error{jwt.ErrTokenExpired},
+		jwt.NewParser(jwt.WithLeeway(time.Minute)),
+		jwt.SigningMethodRS256,
+	},
+	{
+		"basic expired with 120s skew",
+		"", // autogen
+		defaultKeyFunc,
+		jwt.MapClaims{"foo": "bar", "exp": float64(time.Now().Unix() - 100)},
+		true,
+		0,
+		nil,
+		jwt.NewParser(jwt.WithLeeway(2 * time.Minute)),
+		jwt.SigningMethodRS256,
+	},
+	{
 		"basic nbf",
 		"", // autogen
 		defaultKeyFunc,
@@ -87,6 +109,28 @@ var jwtTestData = []struct {
 		jwt.ValidationErrorNotValidYet,
 		[]error{jwt.ErrTokenNotValidYet},
 		nil,
+		jwt.SigningMethodRS256,
+	},
+	{
+		"basic nbf with 60s skew",
+		"", // autogen
+		defaultKeyFunc,
+		jwt.MapClaims{"foo": "bar", "nbf": float64(time.Now().Unix() + 100)},
+		false,
+		jwt.ValidationErrorNotValidYet,
+		[]error{jwt.ErrTokenNotValidYet},
+		jwt.NewParser(jwt.WithLeeway(time.Minute)),
+		jwt.SigningMethodRS256,
+	},
+	{
+		"basic nbf with 120s skew",
+		"", // autogen
+		defaultKeyFunc,
+		jwt.MapClaims{"foo": "bar", "nbf": float64(time.Now().Unix() + 100)},
+		true,
+		0,
+		nil,
+		jwt.NewParser(jwt.WithLeeway(2 * time.Minute)),
 		jwt.SigningMethodRS256,
 	},
 	{

--- a/validator_option.go
+++ b/validator_option.go
@@ -1,0 +1,29 @@
+package jwt
+
+import "time"
+
+// validationOption is used to implement functional-style options that modify the behavior of the parser. To add
+// new options, just create a function (ideally beginning with With or Without) that returns an anonymous function that
+// takes a *validator type as input and manipulates its configuration accordingly.
+//
+// Note that this struct is (currently) un-exported, its naming is subject to change and will only be exported once
+// the API is more stable.
+type validationOption func(*validator)
+
+// validator represents options that can be used for claims validation
+//
+// Note that this struct is (currently) un-exported, its naming is subject to change and will only be exported once
+// the API is more stable.
+type validator struct {
+	leeway time.Duration // Leeway to provide when validating time values
+}
+
+// withLeeway is an option to set the clock skew (leeway) window
+//
+// Note that this function is (currently) un-exported, its naming is subject to change and will only be exported once
+// the API is more stable.
+func withLeeway(d time.Duration) validationOption {
+	return func(v *validator) {
+		v.leeway = d
+	}
+}


### PR DESCRIPTION
This PR is part of a series of experiments, to see which options we have to implement validation options in a backwards compatible way. I want to get a fell about our options first and some feedback from the community, before we implement all desired options. I am looking to gather feedback here: https://github.com/golang-jwt/jwt/discussions/211

Option 3 is to create a new `ClaimsWithOptions` interface next to `Claims`, which provides an additional `ValidWithOptions` function in the claims to check validations with options. `Valid` is then redirected to `ValidWithOptions`

Pros:
* Should not break anything and seems to be transparent to the user

Cons:
* It's kind of a mess behind the scenes and it introduces a new interface that is sort of a workaround that we might want to get rid of in v5 again if we decide to break the api and just supply options to `Valid` directly.