### PR TITLE
chore: remove unused claims in table driven test - part2

### DIFF
--- a/ecdsa_test.go
+++ b/ecdsa_test.go
@@ -14,7 +14,6 @@ var ecdsaTestData = []struct {
 	keys        map[string]string
 	tokenString string
 	alg         string
-	claims      map[string]interface{}
 	valid       bool
 }{
 	{
@@ -22,7 +21,6 @@ var ecdsaTestData = []struct {
 		map[string]string{"private": "test/ec256-private.pem", "public": "test/ec256-public.pem"},
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJmb28iOiJiYXIifQ.feG39E-bn8HXAKhzDZq7yEAPWYDhZlwTn3sePJnU9VrGMmwdXAIEyoOnrjreYlVM_Z4N13eK9-TmMTWyfKJtHQ",
 		"ES256",
-		map[string]interface{}{"foo": "bar"},
 		true,
 	},
 	{
@@ -30,7 +28,6 @@ var ecdsaTestData = []struct {
 		map[string]string{"private": "test/ec384-private.pem", "public": "test/ec384-public.pem"},
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzM4NCJ9.eyJmb28iOiJiYXIifQ.ngAfKMbJUh0WWubSIYe5GMsA-aHNKwFbJk_wq3lq23aPp8H2anb1rRILIzVR0gUf4a8WzDtrzmiikuPWyCS6CN4-PwdgTk-5nehC7JXqlaBZU05p3toM3nWCwm_LXcld",
 		"ES384",
-		map[string]interface{}{"foo": "bar"},
 		true,
 	},
 	{
@@ -38,7 +35,6 @@ var ecdsaTestData = []struct {
 		map[string]string{"private": "test/ec512-private.pem", "public": "test/ec512-public.pem"},
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzUxMiJ9.eyJmb28iOiJiYXIifQ.AAU0TvGQOcdg2OvrwY73NHKgfk26UDekh9Prz-L_iWuTBIBqOFCWwwLsRiHB1JOddfKAls5do1W0jR_F30JpVd-6AJeTjGKA4C1A1H6gIKwRY0o_tFDIydZCl_lMBMeG5VNFAjO86-WCSKwc3hqaGkq1MugPRq_qrF9AVbuEB4JPLyL5",
 		"ES512",
-		map[string]interface{}{"foo": "bar"},
 		true,
 	},
 	{
@@ -46,7 +42,6 @@ var ecdsaTestData = []struct {
 		map[string]string{"private": "test/ec256-private.pem", "public": "test/ec256-public.pem"},
 		"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.MEQCIHoSJnmGlPaVQDqacx_2XlXEhhqtWceVopjomc2PJLtdAiAUTeGPoNYxZw0z8mgOnnIcjoxRuNDVZvybRZF3wR1l8W",
 		"ES256",
-		map[string]interface{}{"foo": "bar"},
 		false,
 	},
 }

--- a/ed25519_test.go
+++ b/ed25519_test.go
@@ -13,7 +13,6 @@ var ed25519TestData = []struct {
 	keys        map[string]string
 	tokenString string
 	alg         string
-	claims      map[string]interface{}
 	valid       bool
 }{
 	{
@@ -21,7 +20,6 @@ var ed25519TestData = []struct {
 		map[string]string{"private": "test/ed25519-private.pem", "public": "test/ed25519-public.pem"},
 		"eyJhbGciOiJFRDI1NTE5IiwidHlwIjoiSldUIn0.eyJmb28iOiJiYXIifQ.ESuVzZq1cECrt9Od_gLPVG-_6uRP_8Nq-ajx6CtmlDqRJZqdejro2ilkqaQgSL-siE_3JMTUW7UwAorLaTyFCw",
 		"EdDSA",
-		map[string]interface{}{"foo": "bar"},
 		true,
 	},
 	{
@@ -29,7 +27,6 @@ var ed25519TestData = []struct {
 		map[string]string{"private": "test/ed25519-private.pem", "public": "test/ed25519-public.pem"},
 		"eyJhbGciOiJFRDI1NTE5IiwidHlwIjoiSldUIn0.eyJmb28iOiJiYXoifQ.ESuVzZq1cECrt9Od_gLPVG-_6uRP_8Nq-ajx6CtmlDqRJZqdejro2ilkqaQgSL-siE_3JMTUW7UwAorLaTyFCw",
 		"EdDSA",
-		map[string]interface{}{"foo": "bar"},
 		false,
 	},
 }

--- a/hmac_test.go
+++ b/hmac_test.go
@@ -12,35 +12,30 @@ var hmacTestData = []struct {
 	name        string
 	tokenString string
 	alg         string
-	claims      map[string]interface{}
 	valid       bool
 }{
 	{
 		"web sample",
 		"eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
 		"HS256",
-		map[string]interface{}{"iss": "joe", "exp": 1300819380, "http://example.com/is_root": true},
 		true,
 	},
 	{
 		"HS384",
 		"eyJhbGciOiJIUzM4NCIsInR5cCI6IkpXVCJ9.eyJleHAiOjEuMzAwODE5MzhlKzA5LCJodHRwOi8vZXhhbXBsZS5jb20vaXNfcm9vdCI6dHJ1ZSwiaXNzIjoiam9lIn0.KWZEuOD5lbBxZ34g7F-SlVLAQ_r5KApWNWlZIIMyQVz5Zs58a7XdNzj5_0EcNoOy",
 		"HS384",
-		map[string]interface{}{"iss": "joe", "exp": 1300819380, "http://example.com/is_root": true},
 		true,
 	},
 	{
 		"HS512",
 		"eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJleHAiOjEuMzAwODE5MzhlKzA5LCJodHRwOi8vZXhhbXBsZS5jb20vaXNfcm9vdCI6dHJ1ZSwiaXNzIjoiam9lIn0.CN7YijRX6Aw1n2jyI2Id1w90ja-DEMYiWixhYCyHnrZ1VfJRaFQz1bEbjjA5Fn4CLYaUG432dEYmSbS4Saokmw",
 		"HS512",
-		map[string]interface{}{"iss": "joe", "exp": 1300819380, "http://example.com/is_root": true},
 		true,
 	},
 	{
 		"web sample: invalid",
 		"eyJ0eXAiOiJKV1QiLA0KICJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFtcGxlLmNvbS9pc19yb290Ijp0cnVlfQ.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXo",
 		"HS256",
-		map[string]interface{}{"iss": "joe", "exp": 1300819380, "http://example.com/is_root": true},
 		false,
 	},
 }

--- a/none_test.go
+++ b/none_test.go
@@ -12,7 +12,6 @@ var noneTestData = []struct {
 	tokenString string
 	alg         string
 	key         interface{}
-	claims      map[string]interface{}
 	valid       bool
 }{
 	{
@@ -20,7 +19,6 @@ var noneTestData = []struct {
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.",
 		"none",
 		jwt.UnsafeAllowNoneSignatureType,
-		map[string]interface{}{"foo": "bar"},
 		true,
 	},
 	{
@@ -28,7 +26,6 @@ var noneTestData = []struct {
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.",
 		"none",
 		nil,
-		map[string]interface{}{"foo": "bar"},
 		false,
 	},
 	{
@@ -36,7 +33,6 @@ var noneTestData = []struct {
 		"eyJhbGciOiJSUzM4NCIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.W-jEzRfBigtCWsinvVVuldiuilzVdU5ty0MvpLaSaqK9PlAWWlDQ1VIQ_qSKzwL5IXaZkvZFJXT3yL3n7OUVu7zCNJzdwznbC8Z-b0z2lYvcklJYi2VOFRcGbJtXUqgjk2oGsiqUMUMOLP70TTefkpsgqDxbRh9CDUfpOJgW-dU7cmgaoswe3wjUAUi6B6G2YEaiuXC0XScQYSYVKIzgKXJV8Zw-7AN_DBUI4GkTpsvQ9fVVjZM9csQiEXhYekyrKu1nu_POpQonGd8yqkIyXPECNmmqH5jH4sFiF67XhD7_JpkvLziBpI-uh86evBUadmHhb9Otqw3uV3NTaXLzJw",
 		"none",
 		jwt.UnsafeAllowNoneSignatureType,
-		map[string]interface{}{"foo": "bar"},
 		false,
 	},
 }

--- a/rsa_pss_test.go
+++ b/rsa_pss_test.go
@@ -18,35 +18,30 @@ var rsaPSSTestData = []struct {
 	name        string
 	tokenString string
 	alg         string
-	claims      map[string]interface{}
 	valid       bool
 }{
 	{
 		"Basic PS256",
 		"eyJhbGciOiJQUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.PPG4xyDVY8ffp4CcxofNmsTDXsrVG2npdQuibLhJbv4ClyPTUtR5giNSvuxo03kB6I8VXVr0Y9X7UxhJVEoJOmULAwRWaUsDnIewQa101cVhMa6iR8X37kfFoiZ6NkS-c7henVkkQWu2HtotkEtQvN5hFlk8IevXXPmvZlhQhwzB1sGzGYnoi1zOfuL98d3BIjUjtlwii5w6gYG2AEEzp7HnHCsb3jIwUPdq86Oe6hIFjtBwduIK90ca4UqzARpcfwxHwVLMpatKask00AgGVI0ysdk0BLMjmLutquD03XbThHScC2C2_Pp4cHWgMzvbgLU2RYYZcZRKr46QeNgz9w",
 		"PS256",
-		map[string]interface{}{"foo": "bar"},
 		true,
 	},
 	{
 		"Basic PS384",
 		"eyJhbGciOiJQUzM4NCIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.w7-qqgj97gK4fJsq_DCqdYQiylJjzWONvD0qWWWhqEOFk2P1eDULPnqHRnjgTXoO4HAw4YIWCsZPet7nR3Xxq4ZhMqvKW8b7KlfRTb9cH8zqFvzMmybQ4jv2hKc3bXYqVow3AoR7hN_CWXI3Dv6Kd2X5xhtxRHI6IL39oTVDUQ74LACe-9t4c3QRPuj6Pq1H4FAT2E2kW_0KOc6EQhCLWEhm2Z2__OZskDC8AiPpP8Kv4k2vB7l0IKQu8Pr4RcNBlqJdq8dA5D3hk5TLxP8V5nG1Ib80MOMMqoS3FQvSLyolFX-R_jZ3-zfq6Ebsqr0yEb0AH2CfsECF7935Pa0FKQ",
 		"PS384",
-		map[string]interface{}{"foo": "bar"},
 		true,
 	},
 	{
 		"Basic PS512",
 		"eyJhbGciOiJQUzUxMiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.GX1HWGzFaJevuSLavqqFYaW8_TpvcjQ8KfC5fXiSDzSiT9UD9nB_ikSmDNyDILNdtjZLSvVKfXxZJqCfefxAtiozEDDdJthZ-F0uO4SPFHlGiXszvKeodh7BuTWRI2wL9-ZO4mFa8nq3GMeQAfo9cx11i7nfN8n2YNQ9SHGovG7_T_AvaMZB_jT6jkDHpwGR9mz7x1sycckEo6teLdHRnH_ZdlHlxqknmyTu8Odr5Xh0sJFOL8BepWbbvIIn-P161rRHHiDWFv6nhlHwZnVzjx7HQrWSGb6-s2cdLie9QL_8XaMcUpjLkfOMKkDOfHo6AvpL7Jbwi83Z2ZTHjJWB-A",
 		"PS512",
-		map[string]interface{}{"foo": "bar"},
 		true,
 	},
 	{
 		"basic PS256 invalid: foo => bar",
 		"eyJhbGciOiJQUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIifQ.PPG4xyDVY8ffp4CcxofNmsTDXsrVG2npdQuibLhJbv4ClyPTUtR5giNSvuxo03kB6I8VXVr0Y9X7UxhJVEoJOmULAwRWaUsDnIewQa101cVhMa6iR8X37kfFoiZ6NkS-c7henVkkQWu2HtotkEtQvN5hFlk8IevXXPmvZlhQhwzB1sGzGYnoi1zOfuL98d3BIjUjtlwii5w6gYG2AEEzp7HnHCsb3jIwUPdq86Oe6hIFjtBwduIK90ca4UqzARpcfwxHwVLMpatKask00AgGVI0ysdk0BLMjmLutquD03XbThHScC2C2_Pp4cHWgMzvbgLU2RYYZcZRKr46QeNgz9W",
 		"PS256",
-		map[string]interface{}{"foo": "bar"},
 		false,
 	},
 }


### PR DESCRIPTION
Followup PR: https://github.com/golang-jwt/jwt/pull/212

Noticed that `claims` are not used in various table-driven tests around the project. With this PR we clean them up. Sorry for not noticing in https://github.com/golang-jwt/jwt/pull/212.