### PR TITLE
Implement a BearerExtractor

### DIFF
--- a/request/extractor.go
+++ b/request/extractor.go
@@ -3,6 +3,7 @@ package request
 import (
 	"errors"
 	"net/http"
+	"strings"
 )
 
 // Errors
@@ -78,4 +79,17 @@ func (e *PostExtractionFilter) ExtractToken(req *http.Request) (string, error) {
 	} else {
 		return "", err
 	}
+}
+
+// BearerExtractor extracts a token from the Authorization header.
+// The header is expected to match the format "Bearer XX", where "XX" is the
+// JWT token.
+type BearerExtractor struct{}
+
+func (e BearerExtractor) ExtractToken(req *http.Request) (string, error) {
+	tokenHeader := req.Header.Get("Authorization")
+	if tokenHeader == "" || !strings.HasPrefix(tokenHeader, "Bearer ") {
+		return "", ErrNoTokenInRequest
+	}
+	return strings.TrimPrefix(tokenHeader, "Bearer "), nil
 }

--- a/request/extractor.go
+++ b/request/extractor.go
@@ -88,8 +88,10 @@ type BearerExtractor struct{}
 
 func (e BearerExtractor) ExtractToken(req *http.Request) (string, error) {
 	tokenHeader := req.Header.Get("Authorization")
-	if tokenHeader == "" || !strings.HasPrefix(tokenHeader, "Bearer ") {
+	// The usual convention is for "Bearer" to be title-cased. However, there's no
+	// strict rule around this, and it's best to follow the robustness principle here.
+	if tokenHeader == "" || !strings.HasPrefix(strings.ToLower(tokenHeader), "bearer ") {
 		return "", ErrNoTokenInRequest
 	}
-	return strings.TrimPrefix(tokenHeader, "Bearer "), nil
+	return tokenHeader[7:], nil
 }

--- a/request/extractor_test.go
+++ b/request/extractor_test.go
@@ -91,16 +91,21 @@ func makeExampleRequest(method, path string, headers map[string]string, urlArgs 
 }
 
 func TestBearerExtractor(t *testing.T) {
-	request := makeExampleRequest("POST", "https://example.com/", map[string]string{"Authorization": "Bearer 123"}, nil)
+	request := makeExampleRequest("POST", "https://example.com/", map[string]string{"Authorization": "Bearer ToKen"}, nil)
 	token, err := BearerExtractor{}.ExtractToken(request)
-	if err != nil || token != "123" {
+	if err != nil || token != "ToKen" {
 		t.Errorf("ExtractToken did not return token, returned: %v, %v", token, err)
 	}
 
-	request = makeExampleRequest("POST", "https://example.com/", map[string]string{"Authorization": "Bearo 123"}, nil)
-
+	request = makeExampleRequest("POST", "https://example.com/", map[string]string{"Authorization": "Bearo ToKen"}, nil)
 	token, err = BearerExtractor{}.ExtractToken(request)
 	if err == nil || token != "" {
 		t.Errorf("ExtractToken did not return error, returned: %v, %v", token, err)
+	}
+
+	request = makeExampleRequest("POST", "https://example.com/", map[string]string{"Authorization": "BeArEr HeLO"}, nil)
+	token, err = BearerExtractor{}.ExtractToken(request)
+	if err != nil || token != "HeLO" {
+		t.Errorf("ExtractToken did not return token, returned: %v, %v", token, err)
 	}
 }

--- a/request/extractor_test.go
+++ b/request/extractor_test.go
@@ -89,3 +89,18 @@ func makeExampleRequest(method, path string, headers map[string]string, urlArgs 
 	}
 	return r
 }
+
+func TestBearerExtractor(t *testing.T) {
+	request := makeExampleRequest("POST", "https://example.com/", map[string]string{"Authorization": "Bearer 123"}, nil)
+	token, err := BearerExtractor{}.ExtractToken(request)
+	if err != nil || token != "123" {
+		t.Errorf("ExtractToken did not return token, returned: %v, %v", token, err)
+	}
+
+	request = makeExampleRequest("POST", "https://example.com/", map[string]string{"Authorization": "Bearo 123"}, nil)
+
+	token, err = BearerExtractor{}.ExtractToken(request)
+	if err == nil || token != "" {
+		t.Errorf("ExtractToken did not return error, returned: %v, %v", token, err)
+	}
+}


### PR DESCRIPTION
This is a rather common extractor; it extracts the JWT from the HTTP
Authorization header, expecting it to include the "Bearer " prefix.

This patterns is rather common and this snippet is repeated in enough
applications that it's probably best to just include it upstream and
allow reusing it.

