### PR TITLE
Bump matrix to support latest go version (go1.19)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [1.16, 1.17, 1.18]
+        go: [1.17, 1.18, 1.19]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/cmd/jwt/main.go
+++ b/cmd/jwt/main.go
@@ -3,7 +3,8 @@
 //
 // Example usage:
 // The following will create and sign a token, then verify it and output the original claims.
-//     echo {\"foo\":\"bar\"} | bin/jwt -key test/sample_key -alg RS256 -sign - | bin/jwt -key test/sample_key.pub -verify -
+//
+//	echo {\"foo\":\"bar\"} | bin/jwt -key test/sample_key -alg RS256 -sign - | bin/jwt -key test/sample_key.pub -verify -
 package main
 
 import (


### PR DESCRIPTION
This PR bumps the matrix of supported Go versions, adding stable go1.19