### PR TITLE
Add doc comment to ParseWithClaims

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -42,6 +42,10 @@ func (p *Parser) Parse(tokenString string, keyFunc Keyfunc) (*Token, error) {
 	return p.ParseWithClaims(tokenString, MapClaims{}, keyFunc)
 }
 
+// ParseWithClaims parses, validates, and verifies like Parse, but supplies a default
+// object implementing the Claims interface. This provides default values which
+// can be overridden and allows a caller to use their own type, rather than
+// the default MapClaims implementation of Claims.
 func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyfunc) (*Token, error) {
 	token, parts, err := p.ParseUnverified(tokenString, claims)
 	if err != nil {


### PR DESCRIPTION
It's not obvious how this works from the name and similar functions. Both in why you might pass an empty object (which is common, to change the type being parsed to) and whether a nonempty object overwrites fields from the token or is overwritten by the token.