### PR TITLE
add documentation to hmac `Verify` & `Sign` to detail why string is not an advisable input for key

### DIFF
--- a/hmac.go
+++ b/hmac.go
@@ -46,7 +46,19 @@ func (m *SigningMethodHMAC) Alg() string {
 }
 
 // Verify implements token verification for the SigningMethod. Returns nil if the signature is valid.
+<<<<<<< HEAD
 func (m *SigningMethodHMAC) Verify(signingString string, sig []byte, key interface{}) error {
+=======
+// Key must be []byte
+// Note it is not advised to provide a []byte which was converted from a 'human readable' string using a subset of ASCII characters.
+// To maximize entropy, you should ideally be providing a []byte key which was produced from a cryptographically random source.
+// i.e. crypto/rand https://pkg.go.dev/crypto/rand#Read
+//
+// Storing keys in the environment can be done by base64 encoding the cryptographically random []byte.
+// Reading keys from the environment can be done by base64 decoding the environment variable to retrieve the original cryptographically random []byte.
+// i.e. encoding/base64 https://pkg.go.dev/encoding/base64#Encoding.DecodeString
+func (m *SigningMethodHMAC) Verify(signingString, signature string, key interface{}) error {
+>>>>>>> a2dc764 (add documentation around Verify & Sign to detail why string is not an advisable input for key)
 	// Verify the key is the right type
 	keyBytes, ok := key.([]byte)
 	if !ok {
@@ -71,8 +83,14 @@ func (m *SigningMethodHMAC) Verify(signingString string, sig []byte, key interfa
 	return nil
 }
 
-// Sign implements token signing for the SigningMethod.
-// Key must be []byte
+// Sign implements token signing for the SigningMethod. Key must be []byte.
+//
+// Note it is not advised to provide a []byte which was converted from a 'human
+// readable' string using a subset of ASCII characters. To maximize entropy, you
+// should ideally be providing a []byte key which was produced from a
+// cryptographically random source, e.g. crypto/rand. Additional information
+// about this, and why we intentionally are not supporting string as a key can
+// be found on our usage guide https://golang-jwt.github.io/jwt/usage/signing_methods/.
 func (m *SigningMethodHMAC) Sign(signingString string, key interface{}) ([]byte, error) {
 	if keyBytes, ok := key.([]byte); ok {
 		if !m.Hash.Available() {

--- a/hmac.go
+++ b/hmac.go
@@ -45,20 +45,17 @@ func (m *SigningMethodHMAC) Alg() string {
 	return m.Name
 }
 
-// Verify implements token verification for the SigningMethod. Returns nil if the signature is valid.
-<<<<<<< HEAD
-func (m *SigningMethodHMAC) Verify(signingString string, sig []byte, key interface{}) error {
-=======
-// Key must be []byte
-// Note it is not advised to provide a []byte which was converted from a 'human readable' string using a subset of ASCII characters.
-// To maximize entropy, you should ideally be providing a []byte key which was produced from a cryptographically random source.
-// i.e. crypto/rand https://pkg.go.dev/crypto/rand#Read
+// Verify implements token verification for the SigningMethod. Returns nil if
+// the signature is valid. Key must be []byte.
 //
-// Storing keys in the environment can be done by base64 encoding the cryptographically random []byte.
-// Reading keys from the environment can be done by base64 decoding the environment variable to retrieve the original cryptographically random []byte.
-// i.e. encoding/base64 https://pkg.go.dev/encoding/base64#Encoding.DecodeString
-func (m *SigningMethodHMAC) Verify(signingString, signature string, key interface{}) error {
->>>>>>> a2dc764 (add documentation around Verify & Sign to detail why string is not an advisable input for key)
+// Note it is not advised to provide a []byte which was converted from a 'human
+// readable' string using a subset of ASCII characters. To maximize entropy, you
+// should ideally be providing a []byte key which was produced from a
+// cryptographically random source, e.g. crypto/rand. Additional information
+// about this, and why we intentionally are not supporting string as a key can
+// be found on our usage guide
+// https://golang-jwt.github.io/jwt/usage/signing_methods/#signing-methods-and-key-types.
+func (m *SigningMethodHMAC) Verify(signingString string, sig []byte, key interface{}) error {
 	// Verify the key is the right type
 	keyBytes, ok := key.([]byte)
 	if !ok {

--- a/token.go
+++ b/token.go
@@ -42,7 +42,10 @@ func NewWithClaims(method SigningMethod, claims Claims, opts ...TokenOption) *To
 }
 
 // SignedString creates and returns a complete, signed JWT. The token is signed
-// using the SigningMethod specified in the token.
+// using the SigningMethod specified in the token. Please refer to
+// https://golang-jwt.github.io/jwt/usage/signing_methods/#signing-methods-and-key-types
+// for an overview of the different signing methods and their respective key
+// types.
 func (t *Token) SignedString(key interface{}) (string, error) {
 	sstr, err := t.SigningString()
 	if err != nil {


### PR DESCRIPTION
related https://github.com/golang-jwt/jwt/pull/245