### PR TITLE
No pointer embedding in the example

### DIFF
--- a/http_example_test.go
+++ b/http_example_test.go
@@ -73,7 +73,7 @@ type CustomerInfo struct {
 }
 
 type CustomClaimsExample struct {
-	*jwt.RegisteredClaims
+	jwt.RegisteredClaims
 	TokenType string
 	CustomerInfo
 }
@@ -142,7 +142,7 @@ func createToken(user string) (string, error) {
 
 	// set our claims
 	t.Claims = &CustomClaimsExample{
-		&jwt.RegisteredClaims{
+		jwt.RegisteredClaims{
 			// set the expire time
 			// see https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Minute * 1)),

--- a/parser.go
+++ b/parser.go
@@ -42,10 +42,13 @@ func (p *Parser) Parse(tokenString string, keyFunc Keyfunc) (*Token, error) {
 	return p.ParseWithClaims(tokenString, MapClaims{}, keyFunc)
 }
 
-// ParseWithClaims parses, validates, and verifies like Parse, but supplies a default
-// object implementing the Claims interface. This provides default values which
-// can be overridden and allows a caller to use their own type, rather than
-// the default MapClaims implementation of Claims.
+// ParseWithClaims parses, validates, and verifies like Parse, but supplies a default object implementing the Claims
+// interface. This provides default values which can be overridden and allows a caller to use their own type, rather
+// than the default MapClaims implementation of Claims.
+//
+// Note: If you provide a custom claim implementation that embeds one of the standard claims (such as RegisteredClaims),
+// make sure that a) you either embed a non-pointer version of the claims or b) if you are using a pointer, allocate the
+// proper memory for it before passing in the overall claims, otherwise you might run into a panic.
 func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyfunc) (*Token, error) {
 	token, parts, err := p.ParseUnverified(tokenString, claims)
 	if err != nil {

--- a/token.go
+++ b/token.go
@@ -99,6 +99,11 @@ func Parse(tokenString string, keyFunc Keyfunc, options ...ParserOption) (*Token
 	return NewParser(options...).Parse(tokenString, keyFunc)
 }
 
+// ParseWithClaims is a shortcut for NewParser().ParseWithClaims().
+//
+// Note: If you provide a custom claim implementation that embeds one of the standard claims (such as RegisteredClaims),
+// make sure that a) you either embed a non-pointer version of the claims or b) if you are using a pointer, allocate the
+// proper memory for it before passing in the overall claims, otherwise you might run into a panic.
 func ParseWithClaims(tokenString string, claims Claims, keyFunc Keyfunc, options ...ParserOption) (*Token, error) {
 	return NewParser(options...).ParseWithClaims(tokenString, claims, keyFunc)
 }


### PR DESCRIPTION
Embedding a pointer version of `jwt.RegisteredClaims` in a custom claim and passing it to `ParseWithClaims` without memory allocation will lead to a crash if an empty token is presented (see #223). Unfortunately, we cannot really check for this in the function without MAJOR reflection magic, so I fear, all we can do at the moment is adjust the example and add a better description.