### PR TITLE
Adjusting the error checking example

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -164,6 +164,9 @@ func ExampleParse_errorChecking() {
 		fmt.Println("You look nice today")
 	} else if errors.Is(err, jwt.ErrTokenMalformed) {
 		fmt.Println("That's not even a token")
+	} else if errors.Is(err, jwt.ErrTokenSignatureInvalid) {
+		// Invalid signature
+		fmt.Println("Invalid signature")
 	} else if errors.Is(err, jwt.ErrTokenExpired) || errors.Is(err, jwt.ErrTokenNotValidYet) {
 		// Token is either expired or not active yet
 		fmt.Println("Timing is everything")


### PR DESCRIPTION
This PR adjusts the error checking example so that a check for an invalid signature is also included.

See discussion in #143
