### PR TITLE
Adding canonical `Keyfunc` functions for RSA, ECDSA, EdDSA and HMAC

### DIFF
--- a/ecdsa.go
+++ b/ecdsa.go
@@ -132,3 +132,10 @@ func (m *SigningMethodECDSA) Sign(signingString string, key interface{}) ([]byte
 		return nil, err
 	}
 }
+
+// ECDSAPublicKey represents a [Keyfunc] that returns the ECDSA key specified in
+// key. Furthermore, it checks, whether the signing method matches
+// [SigningMethodECDSA].
+func ECDSAPublicKey(key *ecdsa.PublicKey) Keyfunc {
+	return secureKeyFunc(key, []string{"ES256", "ES384", "ES512"})
+}

--- a/ed25519.go
+++ b/ed25519.go
@@ -78,3 +78,10 @@ func (m *SigningMethodEd25519) Sign(signingString string, key interface{}) ([]by
 
 	return sig, nil
 }
+
+// Ed25519PublicKey represents a [Keyfunc] that returns the Ed25519 key
+// specified in key. Furthermore, it checks, whether the signing method matches
+// [SigningMethodEdDSA].
+func Ed25519PublicKey(key ed25519.PublicKey) Keyfunc {
+	return secureKeyFunc(key, []string{"EdDSA"})
+}

--- a/example_test.go
+++ b/example_test.go
@@ -80,9 +80,7 @@ func ExampleParseWithClaims_customClaimsType() {
 		jwt.RegisteredClaims
 	}
 
-	token, err := jwt.ParseWithClaims(tokenString, &MyCustomClaims{}, func(token *jwt.Token) (interface{}, error) {
-		return []byte("AllYourBase"), nil
-	})
+	token, err := jwt.ParseWithClaims(tokenString, &MyCustomClaims{}, jwt.PresharedKey([]byte("AllYourBase")))
 
 	if claims, ok := token.Claims.(*MyCustomClaims); ok && token.Valid {
 		fmt.Printf("%v %v", claims.Foo, claims.RegisteredClaims.Issuer)
@@ -103,9 +101,11 @@ func ExampleParseWithClaims_validationOptions() {
 		jwt.RegisteredClaims
 	}
 
-	token, err := jwt.ParseWithClaims(tokenString, &MyCustomClaims{}, func(token *jwt.Token) (interface{}, error) {
-		return []byte("AllYourBase"), nil
-	}, jwt.WithLeeway(5*time.Second))
+	token, err := jwt.ParseWithClaims(
+		tokenString, &MyCustomClaims{},
+		jwt.PresharedKey([]byte("AllYourBase")),
+		jwt.WithLeeway(5*time.Second),
+	)
 
 	if claims, ok := token.Claims.(*MyCustomClaims); ok && token.Valid {
 		fmt.Printf("%v %v", claims.Foo, claims.RegisteredClaims.Issuer)
@@ -138,9 +138,10 @@ func (m MyCustomClaims) Validate() error {
 func ExampleParseWithClaims_customValidation() {
 	tokenString := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJpc3MiOiJ0ZXN0IiwiYXVkIjoic2luZ2xlIn0.QAWg1vGvnqRuCFTMcPkjZljXHh8U3L_qUjszOtQbeaA"
 
-	token, err := jwt.ParseWithClaims(tokenString, &MyCustomClaims{}, func(token *jwt.Token) (interface{}, error) {
-		return []byte("AllYourBase"), nil
-	}, jwt.WithLeeway(5*time.Second))
+	token, err := jwt.ParseWithClaims(
+		tokenString, &MyCustomClaims{},
+		jwt.PresharedKey([]byte("AllYourBase")),
+		jwt.WithLeeway(5*time.Second))
 
 	if claims, ok := token.Claims.(*MyCustomClaims); ok && token.Valid {
 		fmt.Printf("%v %v", claims.Foo, claims.RegisteredClaims.Issuer)
@@ -156,9 +157,7 @@ func ExampleParse_errorChecking() {
 	// Token from another example.  This token is expired
 	var tokenString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJleHAiOjE1MDAwLCJpc3MiOiJ0ZXN0In0.HE7fK0xOQwFEr4WDgRWj4teRPZ6i3GLwD5YCm6Pwu_c"
 
-	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
-		return []byte("AllYourBase"), nil
-	})
+	token, err := jwt.Parse(tokenString, jwt.PresharedKey([]byte("AllYourBase")))
 
 	if token.Valid {
 		fmt.Println("You look nice today")

--- a/hmac.go
+++ b/hmac.go
@@ -87,3 +87,8 @@ func (m *SigningMethodHMAC) Sign(signingString string, key interface{}) ([]byte,
 
 	return nil, ErrInvalidKeyType
 }
+
+// PresharedKey represents a [Keyfunc] that simply returns the key specified in the byte slice.
+func PresharedKey(key []byte) Keyfunc {
+	return secureKeyFunc(key, []string{"HS256", "HS384", "HS512"})
+}

--- a/parser.go
+++ b/parser.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"strings"
 )
 
@@ -60,17 +59,8 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
 
 	// Verify signing method is in the required set
 	if p.validMethods != nil {
-		var signingMethodValid = false
-		var alg = token.Method.Alg()
-		for _, m := range p.validMethods {
-			if m == alg {
-				signingMethodValid = true
-				break
-			}
-		}
-		if !signingMethodValid {
-			// signing method is not in the listed set
-			return token, newError(fmt.Sprintf("signing method %v is invalid", alg), ErrTokenSignatureInvalid)
+		if err = token.hasValidSigningMethod(p.validMethods); err != nil {
+			return token, err
 		}
 	}
 

--- a/rsa.go
+++ b/rsa.go
@@ -91,3 +91,10 @@ func (m *SigningMethodRSA) Sign(signingString string, key interface{}) ([]byte, 
 		return nil, err
 	}
 }
+
+// RSAPublicKey represents a [Keyfunc] that returns the RSA key specified in
+// key. Furthermore, it checks, whether the signing method matches
+// [SigningMethodRSA].
+func RSAPublicKey(key *rsa.PublicKey) Keyfunc {
+	return secureKeyFunc(key, []string{"RS256", "RS384", "RS512"})
+}

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"crypto"
+	"crypto/ecdsa"
 	"crypto/rsa"
 	"os"
 
@@ -56,7 +57,7 @@ func LoadECPrivateKeyFromDisk(location string) crypto.PrivateKey {
 	return key
 }
 
-func LoadECPublicKeyFromDisk(location string) crypto.PublicKey {
+func LoadECPublicKeyFromDisk(location string) *ecdsa.PublicKey {
 	keyData, e := os.ReadFile(location)
 	if e != nil {
 		panic(e.Error())


### PR DESCRIPTION
This PR adds ready-to-use keyfunc functions for the various signing methods. This should simplify a lot of standard use-cases and also includes a proper signing method check.

This allows for a much cleaner experience in probably 90% of all use cases:

```go
token, err := jwt.ParseWithClaims(
  tokenString, &MyCustomClaims{},
  jwt.PresharedKey([]byte("AllYourBase")),
  jwt.WithLeeway(5*time.Second),
)
```

```go
token, err := jwt.ParseWithClaims(
  tokenString, &MyCustomClaims{},
  jwt.RSAPublicKey(myKey),
  jwt.WithAudience("http://example.com"),
)
```
