### PR TITLE
added support to dynamic sign the claims

### DIFF
--- a/token.go
+++ b/token.go
@@ -71,7 +71,7 @@ func (t *Token) SigningString() (string, error) {
 		return "", err
 	}
 
-	// If payload have header b64 set as true, then don't base64 encode claims
+	// If payload have header b64 set as false, then don't base64 encode claims
 	if enabled, ok := t.Header["b64"].(bool); ok && !enabled {
 		return t.EncodeSegment(h) + "." + string(c), nil
 	}

--- a/token.go
+++ b/token.go
@@ -71,6 +71,11 @@ func (t *Token) SigningString() (string, error) {
 		return "", err
 	}
 
+	// If payload have header b64 set as true, then don't base64 encode claims
+	if enabled, ok := t.Header["b64"].(bool); ok && !enabled {
+		return t.EncodeSegment(h) + "." + string(c), nil
+	}
+
 	return t.EncodeSegment(h) + "." + t.EncodeSegment(c), nil
 }
 

--- a/token_test.go
+++ b/token_test.go
@@ -1,6 +1,8 @@
 package jwt_test
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -59,12 +61,124 @@ func TestToken_SigningString(t1 *testing.T) {
 	}
 }
 
+func TestToken_B64Header(t *testing.T) {
+	type customClaims struct {
+		jwt.RegisteredClaims
+		Value string `json:"value"`
+	}
+
+	type fields struct {
+		Raw       string
+		Method    jwt.SigningMethod
+		Header    map[string]interface{}
+		Claims    customClaims
+		Signature []byte
+	}
+
+	tests := []struct {
+		name         string
+		fields       fields
+		expectString string
+	}{
+		{
+			name:         "no b64 header",
+			expectString: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2YWx1ZSI6ImhlbGxvIHdvcmxkIn0",
+			fields: fields{
+				Raw:    "",
+				Method: jwt.SigningMethodHS256,
+				Header: map[string]interface{}{
+					"typ": "JWT",
+					"alg": jwt.SigningMethodHS256.Alg(),
+				},
+				Claims: customClaims{
+					Value: "hello world",
+				},
+			},
+		}, {
+			name:         "b64 header is false",
+			expectString: `eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsInR5cCI6IkpXVCJ9.{"value":"hello world"}`,
+			fields: fields{
+				Raw:    "",
+				Method: jwt.SigningMethodHS256,
+				Header: map[string]interface{}{
+					"typ": "JWT",
+					"b64": false,
+					"alg": jwt.SigningMethodHS256.Alg(),
+				},
+				Claims: customClaims{
+					Value: "hello world",
+				},
+			},
+		}, {
+			name:         "b64 header is true",
+			expectString: `eyJhbGciOiJIUzI1NiIsImI2NCI6dHJ1ZSwidHlwIjoiSldUIn0.eyJ2YWx1ZSI6ImhlbGxvIHdvcmxkIn0`,
+			fields: fields{
+				Raw:    "",
+				Method: jwt.SigningMethodHS256,
+				Header: map[string]interface{}{
+					"typ": "JWT",
+					"b64": true,
+					"alg": jwt.SigningMethodHS256.Alg(),
+				},
+				Claims: customClaims{
+					Value: "hello world",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t1 *testing.T) {
+			t := &jwt.Token{
+				Raw:       tt.fields.Raw,
+				Method:    tt.fields.Method,
+				Header:    tt.fields.Header,
+				Claims:    tt.fields.Claims,
+				Signature: tt.fields.Signature,
+			}
+			got, err := t.SigningString()
+			if err != nil {
+				t1.Errorf("SigningString() error = %v, Should not output error", err)
+			}
+			jwtSplitted := strings.Split(got, ".")
+
+			var claims customClaims
+			err = json.Unmarshal([]byte(jwtSplitted[1]), &claims)
+			// if we get error does this mean that we got a encoded claims that json can't unmarshal
+			if _, ok := tt.fields.Header["b64"].(bool); !ok && err == nil {
+				t1.Error("Unmarshal() expected to get error but got nil")
+			}
+
+			// if b64 exist in headers and is enabled
+			if enabled, ok := tt.fields.Header["b64"].(bool); ok && enabled && err == nil {
+				t1.Error("Unmarshal() expected to get error but got nil even if claims is not json")
+				return
+			}
+
+			// if b64 exist in headers and is not enabled
+			if enabled, ok := tt.fields.Header["b64"].(bool); ok && !enabled && err != nil {
+				t1.Error("Unmarshal() expected to get nil but got error even if claims is valid json")
+				return
+			}
+
+			//verify that we are able to parse the returned json
+			if err == nil && claims.Value != "hello world" {
+				t1.Errorf("Value by unmarshal is valid, expected to get 'hello world' but got %s", claims.Value)
+				return
+			}
+
+			if got != tt.expectString {
+				t1.Errorf("expected string: expected to get %s, got %s", tt.expectString, got)
+			}
+		})
+	}
+}
+
 func BenchmarkToken_SigningString(b *testing.B) {
 	t := &jwt.Token{
-		Method: jwt.SigningMethodHS256,
+		Method: jwt.SigningMethodRS256,
 		Header: map[string]interface{}{
-			"typ": "JWT",
-			"alg": jwt.SigningMethodHS256.Alg(),
+			"typ": "JWS",
+			"alg": jwt.SigningMethodRS256.Alg(),
 		},
 		Claims: jwt.RegisteredClaims{},
 	}


### PR DESCRIPTION
Hello,

Added support to only sign claims in JWT if b64 header is present and has value `false`. 

This is useful if you need to create a detached JWS.

Instead of `SigningString`returning `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2YWx1ZSI6ImhlbGxvIHdvcmxkIn0` do SigningString now return `eyJhbGciOiJIUzI1NiIsImI2NCI6ZmFsc2UsInR5cCI6IkpXVCJ9.{"value":"hello world"}` Which later on is signed used `SignedString`

Also this PR adds the support b64 header should have: https://www.rfc-editor.org/rfc/rfc7797#page-4

Fixes #294