### PR TITLE
A quick way to validate token string

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -130,9 +130,6 @@ func (p *Parser) ParseUnverified(tokenString string, claims Claims) (token *Toke
 	// parse Header
 	var headerBytes []byte
 	if headerBytes, err = p.DecodeSegment(parts[0]); err != nil {
-		if strings.HasPrefix(strings.ToLower(tokenString), "bearer ") {
-			return token, parts, newError("tokenstring should not contain 'bearer '", ErrTokenMalformed)
-		}
 		return token, parts, newError("could not base64 decode header", ErrTokenMalformed, err)
 	}
 	if err = json.Unmarshal(headerBytes, &token.Header); err != nil {

--- a/request/extractor.go
+++ b/request/extractor.go
@@ -90,7 +90,7 @@ func (e BearerExtractor) ExtractToken(req *http.Request) (string, error) {
 	tokenHeader := req.Header.Get("Authorization")
 	// The usual convention is for "Bearer" to be title-cased. However, there's no
 	// strict rule around this, and it's best to follow the robustness principle here.
-	if tokenHeader == "" || !strings.HasPrefix(strings.ToLower(tokenHeader), "bearer ") {
+	if len(tokenHeader) < 7 || !strings.HasPrefix(strings.ToLower(tokenHeader[:7]), "bearer ") {
 		return "", ErrNoTokenInRequest
 	}
 	return tokenHeader[7:], nil


### PR DESCRIPTION
This PR reduces the scope of ToLower for strings and can provide a significant performance gain when validating Token Strings.

```go
import (
	"strings"
	"testing"
)

var (
	authA = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyIxMjMiOiJka2FzbDtka2FzO2xka2FzbDtka2FzbDtka2FzbDtka2FsO3NrZGw7Y216eC4sbWMsLnp4bWMueix4bWMuLHp4bWMuengsbWMsLnp4bWMuLHp4bWMuLHp4bSxjLiIsImlhdCI6MTY4MDQ0Nzg2OX0.E9n6tm0P1-Z_fj7RmGpk6RpPMQzTJuo7knKNM0sBhvk"
)

func BenchmarkBearer(b *testing.B) {
	b.Run("previous", func(b *testing.B) {
		b.ResetTimer()
		for i := 0; i < b.N; i++ {
			strings.HasPrefix(strings.ToLower(authA), "bearer ")
		}
	})
	b.Run("now", func(b *testing.B) {
		b.ResetTimer()
		for i := 0; i < b.N; i++ {
			strings.HasPrefix(strings.ToLower(authA[:7]), "bearer ")
		}
	})
}

```


```
goos: darwin
goarch: arm64
pkg: awesomeProject
BenchmarkBearer
BenchmarkBearer/previous
BenchmarkBearer/previous-10         	 1675801	       719.9 ns/op
BenchmarkBearer/now
BenchmarkBearer/now-10              	40375887	        28.59 ns/op
```