### PR TITLE
Fixed incorrect sign string (converted to bytes)

### DIFF
--- a/token.go
+++ b/token.go
@@ -52,6 +52,11 @@ func (t *Token) SignedString(key interface{}) (string, error) {
 		return "", err
 	}
 
+	switch key.(type) {
+	case string:
+		key = []byte(key.(string))
+	}
+
 	sig, err := t.Method.Sign(sstr, key)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
there is a problem in case usage of string for signing. you have to convert it into slice bytes. simple fix will avoid this issues.