### PR TITLE
Add error handling to examples

### DIFF
--- a/cmd/jwt/main.go
+++ b/cmd/jwt/main.go
@@ -146,15 +146,15 @@ func verifyToken() error {
 		return data, nil
 	})
 
+	// Print an error if we can't parse for some reason
+	if err != nil {
+		return fmt.Errorf("couldn't parse token: %w", err)
+	}
+
 	// Print some debug data
 	if *flagDebug && token != nil {
 		fmt.Fprintf(os.Stderr, "Header:\n%v\n", token.Header)
 		fmt.Fprintf(os.Stderr, "Claims:\n%v\n", token.Claims)
-	}
-
-	// Print an error if we can't parse for some reason
-	if err != nil {
-		return fmt.Errorf("couldn't parse token: %w", err)
 	}
 
 	// Is token invalid?
@@ -274,7 +274,7 @@ func showToken() error {
 	}
 
 	token, err := jwt.Parse(string(tokData), nil)
-	if token == nil {
+	if err != nil || token == nil {
 		return fmt.Errorf("malformed token: %w", err)
 	}
 

--- a/cmd/jwt/main.go
+++ b/cmd/jwt/main.go
@@ -152,14 +152,9 @@ func verifyToken() error {
 	}
 
 	// Print some debug data
-	if *flagDebug && token != nil {
+	if *flagDebug {
 		fmt.Fprintf(os.Stderr, "Header:\n%v\n", token.Header)
 		fmt.Fprintf(os.Stderr, "Claims:\n%v\n", token.Claims)
-	}
-
-	// Is token invalid?
-	if !token.Valid {
-		return fmt.Errorf("token is invalid")
 	}
 
 	// Print the token details
@@ -274,7 +269,7 @@ func showToken() error {
 	}
 
 	token, err := jwt.Parse(string(tokData), nil)
-	if err != nil || token == nil {
+	if err != nil {
 		return fmt.Errorf("malformed token: %w", err)
 	}
 

--- a/example_test.go
+++ b/example_test.go
@@ -88,11 +88,11 @@ func ExampleParseWithClaims_customClaimsType() {
 		return []byte("AllYourBase"), nil
 	})
 	if err != nil {
-		fmt.Println(err)
+		log.Fatal(err)
 	} else if claims, ok := token.Claims.(*MyCustomClaims); ok {
 		fmt.Println(claims.Foo, claims.RegisteredClaims.Issuer)
 	} else {
-		fmt.Println("ParseWithClaims returned an unknown claims type, cannot proceed")
+		log.Fatal("unknown claims type, cannot proceed")
 	}
 
 	// Output: bar test
@@ -113,12 +113,10 @@ func ExampleParseWithClaims_validationOptions() {
 	}, jwt.WithLeeway(5*time.Second))
 	if err != nil {
 		log.Fatal(err)
-	}
-
-	if claims, ok := token.Claims.(*MyCustomClaims); ok {
+	} else if claims, ok := token.Claims.(*MyCustomClaims); ok {
 		fmt.Println(claims.Foo, claims.RegisteredClaims.Issuer)
 	} else {
-		fmt.Println(err)
+		log.Fatal("unknown claims type, cannot proceed")
 	}
 
 	// Output: bar test
@@ -151,12 +149,10 @@ func ExampleParseWithClaims_customValidation() {
 	}, jwt.WithLeeway(5*time.Second))
 	if err != nil {
 		log.Fatal(err)
-	}
-
-	if claims, ok := token.Claims.(*MyCustomClaims); ok {
+	} else if claims, ok := token.Claims.(*MyCustomClaims); ok {
 		fmt.Println(claims.Foo, claims.RegisteredClaims.Issuer)
 	} else {
-		fmt.Println(err)
+		log.Fatal("unknown claims type, cannot proceed")
 	}
 
 	// Output: bar test

--- a/example_test.go
+++ b/example_test.go
@@ -91,7 +91,7 @@ func ExampleParseWithClaims_customClaimsType() {
 		log.Fatal(err)
 	}
 
-	if claims, ok := token.Claims.(*MyCustomClaims); ok && token.Valid {
+	if claims, ok := token.Claims.(*MyCustomClaims); ok {
 		fmt.Printf("%v %v", claims.Foo, claims.RegisteredClaims.Issuer)
 	} else {
 		fmt.Println(err)
@@ -117,7 +117,7 @@ func ExampleParseWithClaims_validationOptions() {
 		log.Fatal(err)
 	}
 
-	if claims, ok := token.Claims.(*MyCustomClaims); ok && token.Valid {
+	if claims, ok := token.Claims.(*MyCustomClaims); ok {
 		fmt.Printf("%v %v", claims.Foo, claims.RegisteredClaims.Issuer)
 	} else {
 		fmt.Println(err)
@@ -155,7 +155,7 @@ func ExampleParseWithClaims_customValidation() {
 		log.Fatal(err)
 	}
 
-	if claims, ok := token.Claims.(*MyCustomClaims); ok && token.Valid {
+	if claims, ok := token.Claims.(*MyCustomClaims); ok {
 		fmt.Printf("%v %v", claims.Foo, claims.RegisteredClaims.Issuer)
 	} else {
 		fmt.Println(err)
@@ -172,9 +172,6 @@ func ExampleParse_errorChecking() {
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 		return []byte("AllYourBase"), nil
 	})
-	if err != nil {
-		log.Fatal(err)
-	}
 
 	if token.Valid {
 		fmt.Println("You look nice today")

--- a/example_test.go
+++ b/example_test.go
@@ -3,6 +3,7 @@ package jwt_test
 import (
 	"errors"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -86,6 +87,9 @@ func ExampleParseWithClaims_customClaimsType() {
 	token, err := jwt.ParseWithClaims(tokenString, &MyCustomClaims{}, func(token *jwt.Token) (interface{}, error) {
 		return []byte("AllYourBase"), nil
 	})
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	if claims, ok := token.Claims.(*MyCustomClaims); ok && token.Valid {
 		fmt.Printf("%v %v", claims.Foo, claims.RegisteredClaims.Issuer)
@@ -109,6 +113,9 @@ func ExampleParseWithClaims_validationOptions() {
 	token, err := jwt.ParseWithClaims(tokenString, &MyCustomClaims{}, func(token *jwt.Token) (interface{}, error) {
 		return []byte("AllYourBase"), nil
 	}, jwt.WithLeeway(5*time.Second))
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	if claims, ok := token.Claims.(*MyCustomClaims); ok && token.Valid {
 		fmt.Printf("%v %v", claims.Foo, claims.RegisteredClaims.Issuer)
@@ -144,6 +151,9 @@ func ExampleParseWithClaims_customValidation() {
 	token, err := jwt.ParseWithClaims(tokenString, &MyCustomClaims{}, func(token *jwt.Token) (interface{}, error) {
 		return []byte("AllYourBase"), nil
 	}, jwt.WithLeeway(5*time.Second))
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	if claims, ok := token.Claims.(*MyCustomClaims); ok && token.Valid {
 		fmt.Printf("%v %v", claims.Foo, claims.RegisteredClaims.Issuer)
@@ -162,6 +172,9 @@ func ExampleParse_errorChecking() {
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 		return []byte("AllYourBase"), nil
 	})
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	if token.Valid {
 		fmt.Println("You look nice today")

--- a/example_test.go
+++ b/example_test.go
@@ -88,13 +88,11 @@ func ExampleParseWithClaims_customClaimsType() {
 		return []byte("AllYourBase"), nil
 	})
 	if err != nil {
-		log.Fatal(err)
-	}
-
-	if claims, ok := token.Claims.(*MyCustomClaims); ok {
+		fmt.Println(err)
+	} else if claims, ok := token.Claims.(*MyCustomClaims); ok {
 		fmt.Printf("%v %v", claims.Foo, claims.RegisteredClaims.Issuer)
 	} else {
-		fmt.Println(err)
+		fmt.Printf("ParseWithClaims returned an unknown claims type, cannot proceed")
 	}
 
 	// Output: bar test

--- a/example_test.go
+++ b/example_test.go
@@ -26,7 +26,7 @@ func ExampleNewWithClaims_registeredClaims() {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	ss, err := token.SignedString(mySigningKey)
 	fmt.Println(ss, err)
-	//Output: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0IiwiZXhwIjoxNTE2MjM5MDIyfQ.0XN_1Tpp9FszFOonIBpwha0c_SfnNI22DhTnjMshPg8 <nil>
+	// Output: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0IiwiZXhwIjoxNTE2MjM5MDIyfQ.0XN_1Tpp9FszFOonIBpwha0c_SfnNI22DhTnjMshPg8 <nil>
 }
 
 // Example creating a token using a custom claims type. The RegisteredClaims is embedded

--- a/example_test.go
+++ b/example_test.go
@@ -25,7 +25,7 @@ func ExampleNewWithClaims_registeredClaims() {
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	ss, err := token.SignedString(mySigningKey)
-	fmt.Printf("%v %v", ss, err)
+	fmt.Println(ss, err)
 	//Output: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0IiwiZXhwIjoxNTE2MjM5MDIyfQ.0XN_1Tpp9FszFOonIBpwha0c_SfnNI22DhTnjMshPg8 <nil>
 }
 
@@ -68,7 +68,7 @@ func ExampleNewWithClaims_customClaimsType() {
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	ss, err := token.SignedString(mySigningKey)
-	fmt.Printf("%v %v", ss, err)
+	fmt.Println(ss, err)
 
 	//Output: foo: bar
 	//eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJpc3MiOiJ0ZXN0IiwiZXhwIjoxNTE2MjM5MDIyfQ.xVuY2FZ_MRXMIEgVQ7J-TFtaucVFRXUzHm9LmV41goM <nil>
@@ -90,9 +90,9 @@ func ExampleParseWithClaims_customClaimsType() {
 	if err != nil {
 		fmt.Println(err)
 	} else if claims, ok := token.Claims.(*MyCustomClaims); ok {
-		fmt.Printf("%v %v", claims.Foo, claims.RegisteredClaims.Issuer)
+		fmt.Println(claims.Foo, claims.RegisteredClaims.Issuer)
 	} else {
-		fmt.Printf("ParseWithClaims returned an unknown claims type, cannot proceed")
+		fmt.Println("ParseWithClaims returned an unknown claims type, cannot proceed")
 	}
 
 	// Output: bar test
@@ -116,7 +116,7 @@ func ExampleParseWithClaims_validationOptions() {
 	}
 
 	if claims, ok := token.Claims.(*MyCustomClaims); ok {
-		fmt.Printf("%v %v", claims.Foo, claims.RegisteredClaims.Issuer)
+		fmt.Println(claims.Foo, claims.RegisteredClaims.Issuer)
 	} else {
 		fmt.Println(err)
 	}
@@ -154,7 +154,7 @@ func ExampleParseWithClaims_customValidation() {
 	}
 
 	if claims, ok := token.Claims.(*MyCustomClaims); ok {
-		fmt.Printf("%v %v", claims.Foo, claims.RegisteredClaims.Issuer)
+		fmt.Println(claims.Foo, claims.RegisteredClaims.Issuer)
 	} else {
 		fmt.Println(err)
 	}

--- a/hmac_example_test.go
+++ b/hmac_example_test.go
@@ -61,7 +61,7 @@ func ExampleParse_hmac() {
 		log.Fatal(err)
 	}
 
-	if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
+	if claims, ok := token.Claims.(jwt.MapClaims); ok {
 		fmt.Println(claims["foo"], claims["nbf"])
 	} else {
 		fmt.Println(err)

--- a/hmac_example_test.go
+++ b/hmac_example_test.go
@@ -2,6 +2,7 @@ package jwt_test
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"time"
 
@@ -56,6 +57,9 @@ func ExampleParse_hmac() {
 		// hmacSampleSecret is a []byte containing your secret, e.g. []byte("my_secret_key")
 		return hmacSampleSecret, nil
 	})
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
 		fmt.Println(claims["foo"], claims["nbf"])

--- a/http_example_test.go
+++ b/http_example_test.go
@@ -84,9 +84,7 @@ func Example_getTokenViaHTTP() {
 		"user": {"test"},
 		"pass": {"known"},
 	})
-	if err != nil {
-		fatal(err)
-	}
+	fatal(err)
 
 	if res.StatusCode != 200 {
 		fmt.Println("Unexpected status code", res.StatusCode)


### PR DESCRIPTION
The error after calling jwt.Parse is often omitted while other errors are checked. The lack of consistency can be a bit confusing I think, so this PR adds some of the checks in.

Resolves #309 I suppose.