### PR TITLE
Avoid use of json.NewDecoder

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -147,6 +147,9 @@ func (p *Parser) ParseUnverified(tokenString string, claims Claims) (token *Toke
 		return token, parts, newError("could not base64 decode claim", ErrTokenMalformed, err)
 	}
 
+	// If `useJSONNumber` is enabled then we must use *json.Decoder to decode
+	// the claims. However, this comes with a performance penalty so only use
+	// it if we must and, otherwise, simple use json.Unmarshal.
 	if !p.useJSONNumber {
 		// JSON Unmarshal. Special case for map type to avoid weird pointer behavior.
 		if c, ok := token.Claims.(MapClaims); ok {

--- a/parser.go
+++ b/parser.go
@@ -135,7 +135,7 @@ func (p *Parser) ParseUnverified(tokenString string, claims Claims) (token *Toke
 		}
 		return token, parts, newError("could not base64 decode header", ErrTokenMalformed, err)
 	}
-	if err := json.Unmarshal(headerBytes, &token.Header); err != nil {
+	if err = json.Unmarshal(headerBytes, &token.Header); err != nil {
 		return token, parts, newError("could not JSON decode header", ErrTokenMalformed, err)
 	}
 
@@ -157,8 +157,7 @@ func (p *Parser) ParseUnverified(tokenString string, claims Claims) (token *Toke
 	} else {
 		dec := json.NewDecoder(bytes.NewBuffer(claimBytes))
 		dec.UseNumber()
-
-		// JSON Decode.  Special case for map type to avoid weird pointer behavior
+		// JSON Decode. Special case for map type to avoid weird pointer behavior.
 		if c, ok := token.Claims.(MapClaims); ok {
 			err = dec.Decode(&c)
 		} else {

--- a/parser.go
+++ b/parser.go
@@ -154,9 +154,6 @@ func (p *Parser) ParseUnverified(tokenString string, claims Claims) (token *Toke
 		} else {
 			err = json.Unmarshal(claimBytes, &claims)
 		}
-		if err != nil {
-			return token, parts, newError("could not JSON decode claim", ErrTokenMalformed, err)
-		}
 	} else {
 		dec := json.NewDecoder(bytes.NewBuffer(claimBytes))
 		dec.UseNumber()
@@ -167,10 +164,9 @@ func (p *Parser) ParseUnverified(tokenString string, claims Claims) (token *Toke
 		} else {
 			err = dec.Decode(&claims)
 		}
-		// Handle decode error
-		if err != nil {
-			return token, parts, newError("could not JSON decode claim", ErrTokenMalformed, err)
-		}
+	}
+	if err != nil {
+		return token, parts, newError("could not JSON decode claim", ErrTokenMalformed, err)
 	}
 
 	// Lookup signature method


### PR DESCRIPTION
Avoid use of json.NewDecoder if not needed.

I was hanging around here and I noticed #303. This is an attempt to address it. Please let me know what you think. Thanks!

Resolves #303.