### PR TITLE
Using jwt's native `ErrInvalidType` instead of `json.UnsupportedTypeError`

### DIFF
--- a/types.go
+++ b/types.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"reflect"
 	"strconv"
 	"time"
 )
@@ -121,14 +120,14 @@ func (s *ClaimStrings) UnmarshalJSON(data []byte) (err error) {
 		for _, vv := range v {
 			vs, ok := vv.(string)
 			if !ok {
-				return &json.UnsupportedTypeError{Type: reflect.TypeOf(vv)}
+				return ErrInvalidType
 			}
 			aud = append(aud, vs)
 		}
 	case nil:
 		return nil
 	default:
-		return &json.UnsupportedTypeError{Type: reflect.TypeOf(v)}
+		return ErrInvalidType
 	}
 
 	*s = aud


### PR DESCRIPTION
Previously, when parsing claim values, we used `json.UnsupportedTypeError` to denote if a claim string value is not of the correct type. However, this could lead to panics if a nil value is present and the `Error` function of the `json.UnsupportedTypeError` is called, which does not check for nil types.

Instead, we just now use `ErrInvalidType` similar to the map claims.

Fixes #315
