### PR TITLE
Format: add whitespaces, remove empty lines

### DIFF
--- a/ed25519.go
+++ b/ed25519.go
@@ -1,11 +1,10 @@
 package jwt
 
 import (
-	"errors"
-
 	"crypto"
 	"crypto/ed25519"
 	"crypto/rand"
+	"errors"
 )
 
 var (

--- a/example_test.go
+++ b/example_test.go
@@ -25,7 +25,7 @@ func ExampleNewWithClaims_registeredClaims() {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	ss, err := token.SignedString(mySigningKey)
 	fmt.Printf("%v %v", ss, err)
-	//Output: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0IiwiZXhwIjoxNTE2MjM5MDIyfQ.0XN_1Tpp9FszFOonIBpwha0c_SfnNI22DhTnjMshPg8 <nil>
+	// Output: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0IiwiZXhwIjoxNTE2MjM5MDIyfQ.0XN_1Tpp9FszFOonIBpwha0c_SfnNI22DhTnjMshPg8 <nil>
 }
 
 // Example creating a token using a custom claims type. The RegisteredClaims is embedded
@@ -69,8 +69,8 @@ func ExampleNewWithClaims_customClaimsType() {
 	ss, err := token.SignedString(mySigningKey)
 	fmt.Printf("%v %v", ss, err)
 
-	//Output: foo: bar
-	//eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJpc3MiOiJ0ZXN0IiwiZXhwIjoxNTE2MjM5MDIyfQ.xVuY2FZ_MRXMIEgVQ7J-TFtaucVFRXUzHm9LmV41goM <nil>
+	// Output: foo: bar
+	// eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJpc3MiOiJ0ZXN0IiwiZXhwIjoxNTE2MjM5MDIyfQ.xVuY2FZ_MRXMIEgVQ7J-TFtaucVFRXUzHm9LmV41goM <nil>
 }
 
 // Example creating a token using a custom claims type.  The RegisteredClaims is embedded

--- a/http_example_test.go
+++ b/http_example_test.go
@@ -110,11 +110,10 @@ func Example_getTokenViaHTTP() {
 	claims := token.Claims.(*CustomClaimsExample)
 	fmt.Println(claims.CustomerInfo.Name)
 
-	//Output: test
+	// Output: test
 }
 
 func Example_useTokenViaHTTP() {
-
 	// Make a sample token
 	// In a real world situation, this token will have been acquired from
 	// some other API call (see Example_getTokenViaHTTP)

--- a/parser_test.go
+++ b/parser_test.go
@@ -42,7 +42,6 @@ func init() {
 	// Load private keys
 	jwtTestRSAPrivateKey = test.LoadRSAPrivateKeyFromDisk("test/sample_key")
 	jwtTestEC256PrivateKey = test.LoadECPrivateKeyFromDisk("test/ec256-private.pem")
-
 }
 
 var jwtTestData = []struct {
@@ -352,11 +351,9 @@ func signToken(claims jwt.Claims, signingMethod jwt.SigningMethod) string {
 }
 
 func TestParser_Parse(t *testing.T) {
-
 	// Iterate over test data set and run tests
 	for _, data := range jwtTestData {
 		t.Run(data.name, func(t *testing.T) {
-
 			// If the token string is blank, use helper function to generate string
 			if data.tokenString == "" {
 				data.tokenString = signToken(data.claims, data.signingMethod)
@@ -428,7 +425,6 @@ func TestParser_Parse(t *testing.T) {
 }
 
 func TestParser_ParseUnverified(t *testing.T) {
-
 	// Iterate over test data set and run tests
 	for _, data := range jwtTestData {
 		// Skip test data, that intentionally contains malformed tokens, as they would lead to an error
@@ -670,13 +666,11 @@ func TestSetPadding(t *testing.T) {
 					err,
 				)
 			}
-
 		})
 	}
 }
 
 func BenchmarkParseUnverified(b *testing.B) {
-
 	// Iterate over test data set and run tests
 	for _, data := range jwtTestData {
 		// If the token string is blank, use helper function to generate string

--- a/request/extractor_example_test.go
+++ b/request/extractor_example_test.go
@@ -17,7 +17,7 @@ func ExampleHeaderExtractor() {
 	} else {
 		fmt.Println(err)
 	}
-	//Output: A
+	// Output: A
 }
 
 func ExampleArgumentExtractor() {
@@ -28,5 +28,5 @@ func ExampleArgumentExtractor() {
 	} else {
 		fmt.Println(err)
 	}
-	//Output: A
+	// Output: A
 }

--- a/types_test.go
+++ b/types_test.go
@@ -41,7 +41,6 @@ func TestSingleArrayMarshal(t *testing.T) {
 	expected := `"test"`
 
 	b, err := json.Marshal(s)
-
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}


### PR DESCRIPTION
This PR reformats code:

- add a whitespace after `//`;
- sort imports;
- remove unnecessary empty lines.