### PR TITLE
Refactor example: use io.ReadAll instead of io.Copy

### DIFF
--- a/http_example_test.go
+++ b/http_example_test.go
@@ -4,7 +4,6 @@ package jwt_test
 // This is based on a (now outdated) example at https://gist.github.com/cryptix/45c33ecf0ae54828e63b
 
 import (
-	"bytes"
 	"crypto/rsa"
 	"fmt"
 	"io"
@@ -93,11 +92,10 @@ func Example_getTokenViaHTTP() {
 	}
 
 	// Read the token out of the response body
-	buf := new(bytes.Buffer)
-	_, err = io.Copy(buf, res.Body)
+	buf, err := io.ReadAll(res.Body)
 	fatal(err)
 	res.Body.Close()
-	tokenString := strings.TrimSpace(buf.String())
+	tokenString := strings.TrimSpace(string(buf))
 
 	// Parse the token
 	token, err := jwt.ParseWithClaims(tokenString, &CustomClaimsExample{}, func(token *jwt.Token) (interface{}, error) {
@@ -129,11 +127,10 @@ func Example_useTokenViaHTTP() {
 	fatal(err)
 
 	// Read the response body
-	buf := new(bytes.Buffer)
-	_, err = io.Copy(buf, res.Body)
+	buf, err := io.ReadAll(res.Body)
 	fatal(err)
 	res.Body.Close()
-	fmt.Println(buf.String())
+	fmt.Printf("%s", buf)
 
 	// Output: Welcome, foo
 }


### PR DESCRIPTION
This PR refactors examples: `io.ReadAll` is usually used for reading the response body.