### PR TITLE
Refactor: compare strings with strings.EqualFold

### DIFF
--- a/request/extractor.go
+++ b/request/extractor.go
@@ -90,7 +90,7 @@ func (e BearerExtractor) ExtractToken(req *http.Request) (string, error) {
 	tokenHeader := req.Header.Get("Authorization")
 	// The usual convention is for "Bearer" to be title-cased. However, there's no
 	// strict rule around this, and it's best to follow the robustness principle here.
-	if len(tokenHeader) < 7 || !strings.HasPrefix(strings.ToLower(tokenHeader[:7]), "bearer ") {
+	if len(tokenHeader) < 7 || !strings.EqualFold(tokenHeader[:7], "bearer ") {
 		return "", ErrNoTokenInRequest
 	}
 	return tokenHeader[7:], nil

--- a/request/oauth2.go
+++ b/request/oauth2.go
@@ -7,7 +7,7 @@ import (
 // Strips 'Bearer ' prefix from bearer token string
 func stripBearerPrefixFromTokenString(tok string) (string, error) {
 	// Should be a bearer token
-	if len(tok) > 6 && strings.ToUpper(tok[0:7]) == "BEARER " {
+	if len(tok) > 6 && strings.EqualFold(tok[:7], "bearer ") {
 		return tok[7:], nil
 	}
 	return tok, nil


### PR DESCRIPTION
This PR improves further this PR #302 by replacing `strings.HasPrefix(strings.ToLower(a), b) ` with `strings.EqualFold(a, b)`. `strings.ToUpper` replaced also.

Benchmark gives the results
```
goos: darwin
goarch: arm64
pkg: github.com/golang-jwt/jwt/v5/request
BenchmarkBearerExtractor
BenchmarkBearerExtractor/ToLower
BenchmarkBearerExtractor/ToLower-8         	 4398627	       261.5 ns/op	      16 B/op	       1 allocs/op
BenchmarkBearerExtractor/EqualFold
BenchmarkBearerExtractor/EqualFold-8       	41965194	        28.42 ns/op	       0 B/op	       0 allocs/op
```
Code:
```go
import (
	"strings"
	"testing"
)

func BenchmarkBearerExtractor(b *testing.B) {
	b.Run("ToLower", func(b *testing.B) {
		b.ResetTimer()
		for i := 0; i < b.N; i++ {
			strings.HasPrefix(strings.ToLower(authA[:7]), "bearer ")
		}
	})
	b.Run("EqualFold", func(b *testing.B) {
		b.ResetTimer()
		for i := 0; i < b.N; i++ {
			strings.EqualFold(authA[:7], "bearer ")
		}
	})
}

const authA = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyIxMjMiOiJka2FzbDtka2FzO2xka2FzbDtka2FzbDtka2FzbDtka2FsO3NrZGw7Y216eC4sbWMsLnp4bWMueix4bWMuLHp4bWMuengsbWMsLnp4bWMuLHp4bWMuLHp4bSxjLiIsImlhdCI6MTY4MDQ0Nzg2OX0.E9n6tm0P1-Z_fj7RmGpk6RpPMQzTJuo7knKNM0sBhvk"
```

