### PR TITLE
Add explicit ClaimsValidator implementation check for custom claims

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -125,7 +125,7 @@ type MyCustomClaims struct {
 }
 
 // Ensure we implement [jwt.ClaimsValidator] at compile time so we know our custom Validate method is used.
-var _ jwt.ClaimsValidator = MyCustomClaims{}
+var _ jwt.ClaimsValidator = (*MyCustomClaims)(nil)
 
 // Validate can be used to execute additional application-specific claims
 // validation.

--- a/example_test.go
+++ b/example_test.go
@@ -124,6 +124,9 @@ type MyCustomClaims struct {
 	jwt.RegisteredClaims
 }
 
+// Ensure we implement [jwt.ClaimsValidator] at compile time so we know our custom Validate method is used.
+var _ jwt.ClaimsValidator = MyCustomClaims{}
+
 // Validate can be used to execute additional application-specific claims
 // validation.
 func (m MyCustomClaims) Validate() error {


### PR DESCRIPTION
Prevent user from misnaming or fat fingering the Validate() method implementation.