### PR TITLE
Add deprecation notice to `Valid()`

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -9,6 +9,12 @@ import (
 // Claims must just have a Valid method that determines
 // if the token is invalid for any supported reason
 type Claims interface {
+	// Deprecated: Starting with v5, we will change the way the Claims interface
+	// work. This should only impact users that implemented their own claims
+	// struct (without embedding one of the supplied structs). Users of v4
+	// should already try to avoid calling this function directly. In most
+	// cases, it is sufficient to rely on the error messages of
+	// [Parser.ParseWithClaims] or to use the property [Token.Valid].
 	Valid() error
 }
 
@@ -44,10 +50,16 @@ type RegisteredClaims struct {
 	ID string `json:"jti,omitempty"`
 }
 
-// Valid validates time based claims "exp, iat, nbf".
-// There is no accounting for clock skew.
-// As well, if any of the above claims are not in the token, it will still
-// be considered a valid claim.
+// Valid validates time based claims "exp, iat, nbf". There is no accounting for
+// clock skew. As well, if any of the above claims are not in the token, it will
+// still be considered a valid claim.
+//
+// Deprecated: Starting with v5, we will change the way the Claims interface
+// work. This should only impact users that implemented their own claims struct
+// (without embedding one of the supplied structs). Users of v4 should already
+// try to avoid calling this function directly. In most cases, it is sufficient
+// to rely on the error messages of [Parser.ParseWithClaims] or to use the
+// property [Token.Valid].
 func (c RegisteredClaims) Valid() error {
 	vErr := new(ValidationError)
 	now := TimeFunc()

--- a/map_claims.go
+++ b/map_claims.go
@@ -117,10 +117,16 @@ func (m MapClaims) VerifyIssuer(cmp string, req bool) bool {
 	return verifyIss(iss, cmp, req)
 }
 
-// Valid validates time based claims "exp, iat, nbf".
-// There is no accounting for clock skew.
-// As well, if any of the above claims are not in the token, it will still
-// be considered a valid claim.
+// Valid validates time based claims "exp, iat, nbf". There is no accounting for
+// clock skew. As well, if any of the above claims are not in the token, it will
+// still be considered a valid claim.
+//
+// Deprecated: Starting with v5, we will change the way the Claims interface
+// work. This should only impact users that implemented their own claims struct
+// (without embedding one of the supplied structs). Users of v4 should already
+// try to avoid calling this function directly. In most cases, it is sufficient
+// to rely on the error messages of [Parser.ParseWithClaims] or to use the
+// property [Token.Valid].
 func (m MapClaims) Valid() error {
 	vErr := new(ValidationError)
 	now := TimeFunc().Unix()


### PR DESCRIPTION
This PR adds a deprecation notice to `Valid()` to inform users of our v4 branch, that direct usage of the function in a call is discouraged, since v5 changes the way the `Claims` interface looks like. This needs to be backported to the v4 branch and released as v4.5.1

See #348 for an extended discussion
