### PR TITLE
feat: allow making exp claim required

### DIFF
--- a/map_claims_test.go
+++ b/map_claims_test.go
@@ -106,15 +106,6 @@ func TestMapclaimsVerifyExpiresAtInvalidTypeString(t *testing.T) {
 	}
 }
 
-func TestMapclaimsVerifyExpiresRequiredButMissing(t *testing.T) {
-	mapClaims := MapClaims{}
-	want := false
-	got := newValidator(WithRequiredExpiration()).Validate(mapClaims)
-
-	if want != (got == nil) {
-		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, (got == nil))
-	}
-}
 func TestMapClaimsVerifyExpiresAtExpire(t *testing.T) {
 	exp := time.Now()
 	mapClaims := MapClaims{

--- a/map_claims_test.go
+++ b/map_claims_test.go
@@ -106,6 +106,15 @@ func TestMapclaimsVerifyExpiresAtInvalidTypeString(t *testing.T) {
 	}
 }
 
+func TestMapclaimsVerifyExpiresRequiredButMissing(t *testing.T) {
+	mapClaims := MapClaims{}
+	want := false
+	got := newValidator(WithRequiredExpiration()).Validate(mapClaims)
+
+	if want != (got == nil) {
+		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, (got == nil))
+	}
+}
 func TestMapClaimsVerifyExpiresAtExpire(t *testing.T) {
 	exp := time.Now()
 	mapClaims := MapClaims{

--- a/parser_option.go
+++ b/parser_option.go
@@ -58,6 +58,14 @@ func WithIssuedAt() ParserOption {
 	}
 }
 
+// WithRequiredExpiration returns the ParserOption to make exp claim required.
+// By default exp claim is optional.
+func WithRequiredExpiration() ParserOption {
+	return func(p *Parser) {
+		p.validator.requireExp = true
+	}
+}
+
 // WithAudience configures the validator to require the specified audience in
 // the `aud` claim. Validation will fail if the audience is not listed in the
 // token or the `aud` claim is missing.

--- a/parser_option.go
+++ b/parser_option.go
@@ -58,9 +58,9 @@ func WithIssuedAt() ParserOption {
 	}
 }
 
-// WithRequiredExpiration returns the ParserOption to make exp claim required.
+// WithExpirationRequired returns the ParserOption to make exp claim required.
 // By default exp claim is optional.
-func WithRequiredExpiration() ParserOption {
+func WithExpirationRequired() ParserOption {
 	return func(p *Parser) {
 		p.validator.requireExp = true
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -423,6 +423,16 @@ var jwtTestData = []struct {
 		jwt.NewParser(jwt.WithLeeway(2 * time.Minute)),
 		jwt.SigningMethodRS256,
 	},
+	{
+		"rejects if exp is required but missing",
+		"", // autogen
+		defaultKeyFunc,
+		&jwt.RegisteredClaims{},
+		false,
+		[]error{jwt.ErrTokenInvalidClaims},
+		jwt.NewParser(jwt.WithExpirationRequired()),
+		jwt.SigningMethodRS256,
+	},
 }
 
 // signToken creates and returns a signed JWT token using signingMethod.

--- a/validator.go
+++ b/validator.go
@@ -89,7 +89,8 @@ func (v *validator) Validate(claims Claims) error {
 	}
 
 	// We always need to check the expiration time, but usage of the claim
-	// itself is OPTIONAL.
+	// itself is OPTIONAL by default. requireExp overrides this behavior
+	// and makes the exp claim mandatory.
 	if err = v.verifyExpiresAt(claims, now, v.requireExp); err != nil {
 		errs = append(errs, err)
 	}

--- a/validator.go
+++ b/validator.go
@@ -42,6 +42,9 @@ type validator struct {
 	// validation. If unspecified, this defaults to time.Now.
 	timeFunc func() time.Time
 
+	// requireExp specifies whether the exp claim is required
+	requireExp bool
+
 	// verifyIat specifies whether the iat (Issued At) claim will be verified.
 	// According to https://www.rfc-editor.org/rfc/rfc7519#section-4.1.6 this
 	// only specifies the age of the token, but no validation check is
@@ -87,7 +90,7 @@ func (v *validator) Validate(claims Claims) error {
 
 	// We always need to check the expiration time, but usage of the claim
 	// itself is OPTIONAL.
-	if err = v.verifyExpiresAt(claims, now, false); err != nil {
+	if err = v.verifyExpiresAt(claims, now, v.requireExp); err != nil {
 		errs = append(errs, err)
 	}
 


### PR DESCRIPTION
This PR adds a new parser option `WithExpirationRequired` which makes the claim `exp` required.