### PR TITLE
Add ID to Claims interface

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -5,7 +5,7 @@ package jwt
 // common basis for validation, it is required that an implementation is able to
 // supply at least the claim names provided in
 // https://datatracker.ietf.org/doc/html/rfc7519#section-4.1 namely `exp`,
-// `iat`, `nbf`, `iss`, `sub`, `aud` and `jti“.
+// `iat`, `nbf`, `iss`, `sub`, `aud` and `jti`.
 type Claims interface {
 	GetExpirationTime() (*NumericDate, error)
 	GetIssuedAt() (*NumericDate, error)

--- a/claims.go
+++ b/claims.go
@@ -5,7 +5,7 @@ package jwt
 // common basis for validation, it is required that an implementation is able to
 // supply at least the claim names provided in
 // https://datatracker.ietf.org/doc/html/rfc7519#section-4.1 namely `exp`,
-// `iat`, `nbf`, `iss`, `sub` and `aud`.
+// `iat`, `nbf`, `iss`, `sub`, `aud` and `jti“.
 type Claims interface {
 	GetExpirationTime() (*NumericDate, error)
 	GetIssuedAt() (*NumericDate, error)
@@ -13,4 +13,5 @@ type Claims interface {
 	GetIssuer() (string, error)
 	GetSubject() (string, error)
 	GetAudience() (ClaimStrings, error)
+	GetID() (string, error)
 }

--- a/map_claims.go
+++ b/map_claims.go
@@ -39,6 +39,11 @@ func (m MapClaims) GetSubject() (string, error) {
 	return m.parseString("sub")
 }
 
+// GetID implements the Claims interface.
+func (m MapClaims) GetID() (string, error) {
+	return m.parseString("jti")
+}
+
 // parseNumericDate tries to parse a key in the map claims type as a number
 // date. This will succeed, if the underlying type is either a [float64] or a
 // [json.Number]. Otherwise, nil will be returned.

--- a/registered_claims.go
+++ b/registered_claims.go
@@ -61,3 +61,8 @@ func (c RegisteredClaims) GetIssuer() (string, error) {
 func (c RegisteredClaims) GetSubject() (string, error) {
 	return c.Subject, nil
 }
+
+// GetID implements the Claims interface.
+func (c RegisteredClaims) GetID() (string, error) {
+	return c.ID, nil
+}


### PR DESCRIPTION
This patch adds the `jti` claim to the `Claims` interface with a `GetID()` method. It also implements `GetID()` for both `MapClaims` and `RegisteredClaims`.

This makes it easier to use the registered claims (as documented in https://datatracker.ietf.org/doc/html/rfc7519#section-4.1) when you don't know whether you have an instance of `RegisteredClaims` or `MapClaims` to work with.

(I have a a concrete use for this where it saves me a type switch to find out what type of claims I am working with)

I realize that this is a drive-by pull request - if this change is unwanted then please discard it.