### PR TITLE
Improve ErrInvalidKeyType error message and Parse docs

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	ErrInvalidKey                = errors.New("key is invalid")
-	ErrInvalidKeyType            = errors.New("key is of invalid type")
+	ErrInvalidKeyType            = errors.New("key is of invalid go type (should be []byte())")
 	ErrHashUnavailable           = errors.New("the requested hash function is unavailable")
 	ErrTokenMalformed            = errors.New("token is malformed")
 	ErrTokenUnverifiable         = errors.New("token is unverifiable")

--- a/example_test.go
+++ b/example_test.go
@@ -85,6 +85,7 @@ func ExampleParseWithClaims_customClaimsType() {
 	}
 
 	token, err := jwt.ParseWithClaims(tokenString, &MyCustomClaims{}, func(token *jwt.Token) (interface{}, error) {
+    // []byte("AllYourBase") refers to the signing key that is used to sign the claim with
 		return []byte("AllYourBase"), nil
 	})
 	if err != nil {
@@ -109,6 +110,7 @@ func ExampleParseWithClaims_validationOptions() {
 	}
 
 	token, err := jwt.ParseWithClaims(tokenString, &MyCustomClaims{}, func(token *jwt.Token) (interface{}, error) {
+    // []byte("AllYourBase") refers to the signing key that is used to sign the claim with
 		return []byte("AllYourBase"), nil
 	}, jwt.WithLeeway(5*time.Second))
 	if err != nil {
@@ -148,6 +150,7 @@ func ExampleParseWithClaims_customValidation() {
 	tokenString := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJpc3MiOiJ0ZXN0IiwiYXVkIjoic2luZ2xlIn0.QAWg1vGvnqRuCFTMcPkjZljXHh8U3L_qUjszOtQbeaA"
 
 	token, err := jwt.ParseWithClaims(tokenString, &MyCustomClaims{}, func(token *jwt.Token) (interface{}, error) {
+    // []byte("AllYourBase") refers to the signing key that is used to sign the claim with
 		return []byte("AllYourBase"), nil
 	}, jwt.WithLeeway(5*time.Second))
 	if err != nil {
@@ -167,6 +170,7 @@ func ExampleParse_errorChecking() {
 	var tokenString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJleHAiOjE1MDAwLCJpc3MiOiJ0ZXN0In0.HE7fK0xOQwFEr4WDgRWj4teRPZ6i3GLwD5YCm6Pwu_c"
 
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+    // []byte("AllYourBase") refers to the signing key that is used to sign the claim with
 		return []byte("AllYourBase"), nil
 	})
 


### PR DESCRIPTION
This small PR adds 
- a little bit more context to the ErrInvalidKeyType error message "key is of invalid go type (should be []byte())"
- better description of the Parse function

Generally the original error might seem obvious but for some reason it wasn't clear to me that it was specifically referring to the type in Go, I thought it was some kind of error with my jwt token and not my signing key. It seems like an easy fix of just improving the error message slightly so its clearer what is means.

Since I only looked at the example of how parse the jwt into a correct token again I was also really confused as to what "AllYourBase" even meant. Which is why I suggest to add a small comment, so its clear that this is referring to the signing key (which it only is if you read the previous examples and specifically look at the value of the signingKey).