### PR TITLE
Add Azp claim interface

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -5,7 +5,7 @@ package jwt
 // common basis for validation, it is required that an implementation is able to
 // supply at least the claim names provided in
 // https://datatracker.ietf.org/doc/html/rfc7519#section-4.1 namely `exp`,
-// `iat`, `nbf`, `iss`, `sub` and `aud`.
+// `iat`, `nbf`, `iss`, `sub` and `aud`, as well as the optional `azp` claim.
 type Claims interface {
 	GetExpirationTime() (*NumericDate, error)
 	GetIssuedAt() (*NumericDate, error)
@@ -13,4 +13,5 @@ type Claims interface {
 	GetIssuer() (string, error)
 	GetSubject() (string, error)
 	GetAudience() (ClaimStrings, error)
+	GetAzp() (ClaimStrings, error)
 }

--- a/map_claims.go
+++ b/map_claims.go
@@ -39,6 +39,11 @@ func (m MapClaims) GetSubject() (string, error) {
 	return m.parseString("sub")
 }
 
+// GetSubject implements the Claims interface.
+func (m MapClaims) GetAzp() (string, error) {
+	return m.parseString("azp")
+}
+
 // parseNumericDate tries to parse a key in the map claims type as a number
 // date. This will succeed, if the underlying type is either a [float64] or a
 // [json.Number]. Otherwise, nil will be returned.

--- a/registered_claims.go
+++ b/registered_claims.go
@@ -30,6 +30,9 @@ type RegisteredClaims struct {
 
 	// the `jti` (JWT ID) claim. See https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.7
 	ID string `json:"jti,omitempty"`
+
+	// the `azp` (Authorized Party) claim. Optional. See https://openid.net/specs/openid-connect-core-1_0.html#IDToken
+	Azp string `json:"azp,omitempty"`
 }
 
 // GetExpirationTime implements the Claims interface.
@@ -60,4 +63,9 @@ func (c RegisteredClaims) GetIssuer() (string, error) {
 // GetSubject implements the Claims interface.
 func (c RegisteredClaims) GetSubject() (string, error) {
 	return c.Subject, nil
+}
+
+// GetAzp implements the Claims interface.
+func (c RegisteredClaims) GetAzp() (string, error) {
+	return c.Azp, nil
 }


### PR DESCRIPTION
This adds azp (authorized party) claim to the `Claims`. 

We ran into the issue where using OpenID this field comes up very often. It's not part of JWT spec, but it is part of OpenID (https://openid.net/specs/openid-connect-core-1_0.html#IDToken)  Especially in Azure AAD and Auth0. When doing nested OIDC providers. And we are not fully able to validate claims as depending on which authorization method you use they are mixing `aud` and `azp` fields 😿 

This is very similar to https://github.com/golang-jwt/jwt/pull/352
