### PR TITLE
Fix incorrect error return

### DIFF
--- a/hmac.go
+++ b/hmac.go
@@ -91,7 +91,7 @@ func (m *SigningMethodHMAC) Verify(signingString string, sig []byte, key interfa
 func (m *SigningMethodHMAC) Sign(signingString string, key interface{}) ([]byte, error) {
 	if keyBytes, ok := key.([]byte); ok {
 		if !m.Hash.Available() {
-			return nil, newError("HMAC sign expects []byte", ErrInvalidKeyType)
+			return nil, ErrHashUnavailable
 		}
 
 		hasher := hmac.New(m.Hash.New, keyBytes)

--- a/hmac.go
+++ b/hmac.go
@@ -100,5 +100,5 @@ func (m *SigningMethodHMAC) Sign(signingString string, key interface{}) ([]byte,
 		return hasher.Sum(nil), nil
 	}
 
-	return nil, ErrInvalidKeyType
+	return nil, newError("HMAC sign expects []byte", ErrInvalidKeyType)
 }


### PR DESCRIPTION
Error returned by `SigningMethodHMAC.Sign` is incorrect.
Implemented error handling consistent with other signing methods.