### PR TITLE
Trivial: Typo fix for ECDSA error message

### DIFF
--- a/ecdsa.go
+++ b/ecdsa.go
@@ -62,7 +62,7 @@ func (m *SigningMethodECDSA) Verify(signingString string, sig []byte, key interf
 	case *ecdsa.PublicKey:
 		ecdsaKey = k
 	default:
-		return newError("ECDSA verify expects *ecsda.PublicKey", ErrInvalidKeyType)
+		return newError("ECDSA verify expects *ecdsa.PublicKey", ErrInvalidKeyType)
 	}
 
 	if len(sig) != 2*m.KeySize {
@@ -96,7 +96,7 @@ func (m *SigningMethodECDSA) Sign(signingString string, key interface{}) ([]byte
 	case *ecdsa.PrivateKey:
 		ecdsaKey = k
 	default:
-		return nil, newError("ECDSA sign expects *ecsda.PrivateKey", ErrInvalidKeyType)
+		return nil, newError("ECDSA sign expects *ecdsa.PrivateKey", ErrInvalidKeyType)
 	}
 
 	// Create the hasher


### PR DESCRIPTION
The recently improved error messages have a typo in the ECDSA error messages. This PR fixes it.