### PR TITLE
Separate verification into its own function

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -58,6 +58,12 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
 		return token, err
 	}
 
+	return p.VerifyToken(token, parts, claims, keyFunc)
+}
+
+func (p *Parser) VerifyToken(token *Token, parts []string, claims Claims, keyFunc Keyfunc) (*Token, error) {
+	var err error
+
 	// Verify signing method is in the required set
 	if p.validMethods != nil {
 		var signingMethodValid = false


### PR DESCRIPTION
Hello!

I have this use-case where I want to parse the JWT, fetch the secret elsewhere and then verify the JWT.

The current available functions forces me to parse the JWT another time. I want to validate the token, not parse it again.

Thanks,