### PR TITLE
add parser option to skip not before verification

### DIFF
--- a/parser_option.go
+++ b/parser_option.go
@@ -126,3 +126,9 @@ func WithStrictDecoding() ParserOption {
 		p.decodeStrict = true
 	}
 }
+
+func WithoutNotBeforeVerification() ParserOption {
+	return func(p *Parser) {
+		p.validator.skipNbfVerification = true
+	}
+}

--- a/validator.go
+++ b/validator.go
@@ -51,6 +51,10 @@ type Validator struct {
 	// unrealistic, i.e., in the future.
 	verifyIat bool
 
+	// skipNbfVerification specifies whether we want to skip the nbf (Not before)
+	// claim verification. This is useful to check a token upon receiption.
+	skipNbfVerification bool
+
 	// expectedAud contains the audience this token expects. Supplying an empty
 	// string will disable aud checking.
 	expectedAud string
@@ -207,6 +211,11 @@ func (v *Validator) verifyIssuedAt(claims Claims, cmp time.Time, required bool) 
 // Additionally, if any error occurs while retrieving the claim, e.g., when its
 // the wrong type, an ErrTokenUnverifiable error will be returned.
 func (v *Validator) verifyNotBefore(claims Claims, cmp time.Time, required bool) error {
+	// this verification can be skipped if the option is set
+	if v.skipNbfVerification {
+		return nil
+	}
+
 	nbf, err := claims.GetNotBefore()
 	if err != nil {
 		return err


### PR DESCRIPTION
This pr adds a WithoutNotBeforeVerification() ParserOption.

This functionality is needed when you want to verify a token that you received but that is not yet valid. 
One exemplary use case could be a cinema ticket that is valid tomorrow. You receive it today, verify it and want to add it to your wallet. 

I also added test cases. Let me know if something else needs to be changed.