### PR TITLE
Remove global state for audience marshalling

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -12,5 +12,5 @@ type Claims interface {
 	GetNotBefore() (*NumericDate, error)
 	GetIssuer() (string, error)
 	GetSubject() (string, error)
-	GetAudience() (ClaimStrings, error)
+	GetAudience() (*ClaimStrings, error)
 }

--- a/example_test.go
+++ b/example_test.go
@@ -50,7 +50,7 @@ func ExampleNewWithClaims_customClaimsType() {
 			Issuer:    "test",
 			Subject:   "somebody",
 			ID:        "1",
-			Audience:  []string{"somebody_else"},
+			Audience:  jwt.NewClaimStrings([]string{"somebody_else"}),
 		},
 	}
 

--- a/map_claims.go
+++ b/map_claims.go
@@ -25,7 +25,7 @@ func (m MapClaims) GetIssuedAt() (*NumericDate, error) {
 }
 
 // GetAudience implements the Claims interface.
-func (m MapClaims) GetAudience() (ClaimStrings, error) {
+func (m MapClaims) GetAudience() (*ClaimStrings, error) {
 	return m.parseClaimsString("aud")
 }
 
@@ -66,7 +66,7 @@ func (m MapClaims) parseNumericDate(key string) (*NumericDate, error) {
 
 // parseClaimsString tries to parse a key in the map claims type as a
 // [ClaimsStrings] type, which can either be a string or an array of string.
-func (m MapClaims) parseClaimsString(key string) (ClaimStrings, error) {
+func (m MapClaims) parseClaimsString(key string) (*ClaimStrings, error) {
 	var cs []string
 	switch v := m[key].(type) {
 	case string:
@@ -83,7 +83,7 @@ func (m MapClaims) parseClaimsString(key string) (ClaimStrings, error) {
 		}
 	}
 
-	return cs, nil
+	return NewClaimStrings(cs), nil
 }
 
 // parseString tries to parse a key in the map claims type as a [string] type.

--- a/registered_claims.go
+++ b/registered_claims.go
@@ -6,7 +6,7 @@ package jwt
 //
 // This type can be used on its own, but then additional private and
 // public claims embedded in the JWT will not be parsed. The typical use-case
-// therefore is to embedded this in a user-defined claim type.
+// therefore is to embed this in a user-defined claim type.
 //
 // See examples for how to use this with your own claim types.
 type RegisteredClaims struct {
@@ -17,7 +17,7 @@ type RegisteredClaims struct {
 	Subject string `json:"sub,omitempty"`
 
 	// the `aud` (Audience) claim. See https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3
-	Audience ClaimStrings `json:"aud,omitempty"`
+	Audience *ClaimStrings `json:"aud,omitempty"`
 
 	// the `exp` (Expiration Time) claim. See https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4
 	ExpiresAt *NumericDate `json:"exp,omitempty"`
@@ -48,7 +48,7 @@ func (c RegisteredClaims) GetIssuedAt() (*NumericDate, error) {
 }
 
 // GetAudience implements the Claims interface.
-func (c RegisteredClaims) GetAudience() (ClaimStrings, error) {
+func (c RegisteredClaims) GetAudience() (*ClaimStrings, error) {
 	return c.Audience, nil
 }
 

--- a/validator.go
+++ b/validator.go
@@ -232,7 +232,7 @@ func (v *Validator) verifyAudience(claims Claims, cmp string, required bool) err
 		return err
 	}
 
-	if len(aud) == 0 {
+	if aud.Len() == 0 {
 		return errorIfRequired(required, "aud")
 	}
 
@@ -240,7 +240,7 @@ func (v *Validator) verifyAudience(claims Claims, cmp string, required bool) err
 	result := false
 
 	var stringClaims string
-	for _, a := range aud {
+	for _, a := range aud.Claims() {
 		if subtle.ConstantTimeCompare([]byte(a), []byte(cmp)) != 0 {
 			result = true
 		}


### PR DESCRIPTION
Removes the global `MarshalSingleStringAsArray` and makes it configurable per token. This allows safely using both configuration options within the same application.

This is a breaking change so is intended mostly as a straw man for what the fix could look like.