### PR TITLE
chore: bump ci tests to include go1.23

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.20", "1.21", "1.22"]
+        go: [oldstable, stable]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [oldstable, stable]
+        go: ["1.21", "1.22", "1.23"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: stable
           check-latest: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: "1.23"
           check-latest: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6


### PR DESCRIPTION
This PR updates the CI matrix to include go1.23 and drop go1.20 from tests.