### PR TITLE
Bump GitHub workflows and Go versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.21", "1.22", "1.23"]
+        go: ["1.22", "1.23", "1.24"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
           check-latest: true
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest

--- a/cmd/jwt/main.go
+++ b/cmd/jwt/main.go
@@ -91,7 +91,9 @@ func loadData(p string) ([]byte, error) {
 			return nil, err
 		}
 		rdr = f
-		defer f.Close()
+		if err := f.Close(); err != nil {
+			return nil, err
+		}
 	}
 	return io.ReadAll(rdr)
 }

--- a/example_test.go
+++ b/example_test.go
@@ -90,7 +90,7 @@ func ExampleParseWithClaims_customClaimsType() {
 	if err != nil {
 		log.Fatal(err)
 	} else if claims, ok := token.Claims.(*MyCustomClaims); ok {
-		fmt.Println(claims.Foo, claims.RegisteredClaims.Issuer)
+		fmt.Println(claims.Foo, claims.Issuer)
 	} else {
 		log.Fatal("unknown claims type, cannot proceed")
 	}
@@ -114,7 +114,7 @@ func ExampleParseWithClaims_validationOptions() {
 	if err != nil {
 		log.Fatal(err)
 	} else if claims, ok := token.Claims.(*MyCustomClaims); ok {
-		fmt.Println(claims.Foo, claims.RegisteredClaims.Issuer)
+		fmt.Println(claims.Foo, claims.Issuer)
 	} else {
 		log.Fatal("unknown claims type, cannot proceed")
 	}
@@ -153,7 +153,7 @@ func ExampleParseWithClaims_customValidation() {
 	if err != nil {
 		log.Fatal(err)
 	} else if claims, ok := token.Claims.(*MyCustomClaims); ok {
-		fmt.Println(claims.Foo, claims.RegisteredClaims.Issuer)
+		fmt.Println(claims.Foo, claims.Issuer)
 	} else {
 		log.Fatal("unknown claims type, cannot proceed")
 	}

--- a/http_example_test.go
+++ b/http_example_test.go
@@ -92,7 +92,7 @@ func Example_getTokenViaHTTP() {
 	// Read the token out of the response body
 	buf, err := io.ReadAll(res.Body)
 	fatal(err)
-	res.Body.Close()
+	_ = res.Body.Close()
 	tokenString := strings.TrimSpace(string(buf))
 
 	// Parse the token
@@ -104,7 +104,7 @@ func Example_getTokenViaHTTP() {
 	fatal(err)
 
 	claims := token.Claims.(*CustomClaimsExample)
-	fmt.Println(claims.CustomerInfo.Name)
+	fmt.Println(claims.Name)
 
 	// Output: test
 }
@@ -126,7 +126,7 @@ func Example_useTokenViaHTTP() {
 	// Read the response body
 	buf, err := io.ReadAll(res.Body)
 	fatal(err)
-	res.Body.Close()
+	_ = res.Body.Close()
 	fmt.Printf("%s", buf)
 
 	// Output: Welcome, foo
@@ -156,7 +156,7 @@ func authHandler(w http.ResponseWriter, r *http.Request) {
 	// make sure its post
 	if r.Method != "POST" {
 		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintln(w, "No POST", r.Method)
+		_, _ = fmt.Fprintln(w, "No POST", r.Method)
 		return
 	}
 
@@ -168,21 +168,21 @@ func authHandler(w http.ResponseWriter, r *http.Request) {
 	// check values
 	if user != "test" || pass != "known" {
 		w.WriteHeader(http.StatusForbidden)
-		fmt.Fprintln(w, "Wrong info")
+		_, _ = fmt.Fprintln(w, "Wrong info")
 		return
 	}
 
 	tokenString, err := createToken(user)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintln(w, "Sorry, error while Signing Token!")
+		_, _ = fmt.Fprintln(w, "Sorry, error while Signing Token!")
 		log.Printf("Token Signing error: %v\n", err)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/jwt")
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprintln(w, tokenString)
+	_, _ = fmt.Fprintln(w, tokenString)
 }
 
 // only accessible with a valid token
@@ -197,10 +197,10 @@ func restrictedHandler(w http.ResponseWriter, r *http.Request) {
 	// If the token is missing or invalid, return error
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprintln(w, "Invalid token:", err)
+		_, _ = fmt.Fprintln(w, "Invalid token:", err)
 		return
 	}
 
 	// Token is valid
-	fmt.Fprintln(w, "Welcome,", token.Claims.(*CustomClaimsExample).Name)
+	_, _ = fmt.Fprintln(w, "Welcome,", token.Claims.(*CustomClaimsExample).Name)
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -744,7 +744,7 @@ func TestSetPadding(t *testing.T) {
 			// Parse the token
 			var token *jwt.Token
 			var err error
-			var opts []jwt.ParserOption = []jwt.ParserOption{jwt.WithoutClaimsValidation()}
+			var opts = []jwt.ParserOption{jwt.WithoutClaimsValidation()}
 
 			if data.paddedDecode {
 				opts = append(opts, jwt.WithPaddingAllowed())

--- a/validator.go
+++ b/validator.go
@@ -88,7 +88,7 @@ func NewValidator(opts ...ParserOption) *Validator {
 func (v *Validator) Validate(claims Claims) error {
 	var (
 		now  time.Time
-		errs []error = make([]error, 0, 6)
+		errs = make([]error, 0, 6)
 		err  error
 	)
 


### PR DESCRIPTION
This PR does 2 things:

- Adds Go 1.24 to the build matrix
- Updates to use latest golangci-lint (recently updated to /v2 https://golangci-lint.run/product/changelog/#v200)
  - Fix a few code paths for common errors in example code, mainly error checks on close and prints