### PR TITLE
Fixing bug in iat validation when enabled

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -117,7 +117,7 @@ func (v *Validator) Validate(claims Claims) error {
 
 	// Check issued-at if the option is enabled
 	if v.verifyIat {
-		if err = v.verifyIssuedAt(claims, now, false); err != nil {
+		if err = v.verifyIssuedAt(claims, now, true); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/validator_test.go
+++ b/validator_test.go
@@ -64,6 +64,12 @@ func Test_Validator_Validate(t *testing.T) {
 			wantErr: ErrTokenRequiredClaimMissing,
 		},
 		{
+			name:    "expected iat is missing",
+			fields:  fields{verifyIat: true},
+			args:    args{RegisteredClaims{}},
+			wantErr: ErrTokenRequiredClaimMissing,
+		},
+		{
 			name:    "custom validator",
 			fields:  fields{},
 			args:    args{MyCustomClaims{Foo: "not-bar"}},
@@ -81,8 +87,14 @@ func Test_Validator_Validate(t *testing.T) {
 				expectedIss:  tt.fields.expectedIss,
 				expectedSub:  tt.fields.expectedSub,
 			}
-			if err := v.Validate(tt.args.claims); (err != nil) && !errors.Is(err, tt.wantErr) {
-				t.Errorf("validator.Validate() error = %v, wantErr %v", err, tt.wantErr)
+
+			err := v.Validate(tt.args.claims)
+			if err != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("validator.Validate() error = %v, wantErr %v", err, tt.wantErr)
+				}
+			} else if tt.wantErr != nil {
+				t.Errorf("validator.Validate() did not return error, but test expects '%v'", tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
I was using parser options to set `WithIssuedAt()` in my application code, and noticed my unit test unexpectedly did _not_ fail when my test JWTs omitted this field.

Upon inspecting the code, I found `Validate()` seemed to pass `v.verifyIssuedAt` the value `false` for the `required` argument, which effectively ignores validation for this field when its explicitly configured via `WithIssuedAt()`.

Further, I added a testcase to the `validator_test.go` unit tests, and found that my unit test was not failing when I changed back to the old code. Upon inspection, I found that an errant if statement was only testing if the error messages matched _if_ there was an error at all, which will not test if there is _not_ an error even when one is expected.