### PR TITLE
replaced interface{} to any in KeyFunc

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -22,29 +22,29 @@ var (
 	jwtTestEC256PublicKey  crypto.PublicKey
 	jwtTestEC256PrivateKey crypto.PrivateKey
 	paddedKey              crypto.PublicKey
-	defaultKeyFunc         jwt.Keyfunc = func(t *jwt.Token) (interface{}, error) { return jwtTestDefaultKey, nil }
-	ecdsaKeyFunc           jwt.Keyfunc = func(t *jwt.Token) (interface{}, error) { return jwtTestEC256PublicKey, nil }
-	paddedKeyFunc          jwt.Keyfunc = func(t *jwt.Token) (interface{}, error) { return paddedKey, nil }
-	emptyKeyFunc           jwt.Keyfunc = func(t *jwt.Token) (interface{}, error) { return nil, nil }
-	errorKeyFunc           jwt.Keyfunc = func(t *jwt.Token) (interface{}, error) { return nil, errKeyFuncError }
+	defaultKeyFunc         jwt.Keyfunc = func(t *jwt.Token) (any, error) { return jwtTestDefaultKey, nil }
+	ecdsaKeyFunc           jwt.Keyfunc = func(t *jwt.Token) (any, error) { return jwtTestEC256PublicKey, nil }
+	paddedKeyFunc          jwt.Keyfunc = func(t *jwt.Token) (any, error) { return paddedKey, nil }
+	emptyKeyFunc           jwt.Keyfunc = func(t *jwt.Token) (any, error) { return nil, nil }
+	errorKeyFunc           jwt.Keyfunc = func(t *jwt.Token) (any, error) { return nil, errKeyFuncError }
 	nilKeyFunc             jwt.Keyfunc = nil
-	multipleZeroKeyFunc    jwt.Keyfunc = func(t *jwt.Token) (interface{}, error) { return []interface{}{}, nil }
-	multipleEmptyKeyFunc   jwt.Keyfunc = func(t *jwt.Token) (interface{}, error) {
+	multipleZeroKeyFunc    jwt.Keyfunc = func(t *jwt.Token) (any, error) { return []interface{}{}, nil }
+	multipleEmptyKeyFunc   jwt.Keyfunc = func(t *jwt.Token) (any, error) {
 		return jwt.VerificationKeySet{Keys: []jwt.VerificationKey{nil, nil}}, nil
 	}
-	multipleVerificationKeysFunc jwt.Keyfunc = func(t *jwt.Token) (interface{}, error) {
+	multipleVerificationKeysFunc jwt.Keyfunc = func(t *jwt.Token) (any, error) {
 		return []jwt.VerificationKey{jwtTestDefaultKey, jwtTestEC256PublicKey}, nil
 	}
-	multipleLastKeyFunc jwt.Keyfunc = func(t *jwt.Token) (interface{}, error) {
+	multipleLastKeyFunc jwt.Keyfunc = func(t *jwt.Token) (any, error) {
 		return jwt.VerificationKeySet{Keys: []jwt.VerificationKey{jwtTestEC256PublicKey, jwtTestDefaultKey}}, nil
 	}
-	multipleFirstKeyFunc jwt.Keyfunc = func(t *jwt.Token) (interface{}, error) {
+	multipleFirstKeyFunc jwt.Keyfunc = func(t *jwt.Token) (any, error) {
 		return jwt.VerificationKeySet{Keys: []jwt.VerificationKey{jwtTestDefaultKey, jwtTestEC256PublicKey}}, nil
 	}
-	multipleAltTypedKeyFunc jwt.Keyfunc = func(t *jwt.Token) (interface{}, error) {
+	multipleAltTypedKeyFunc jwt.Keyfunc = func(t *jwt.Token) (any, error) {
 		return jwt.VerificationKeySet{Keys: []jwt.VerificationKey{jwtTestDefaultKey, jwtTestDefaultKey}}, nil
 	}
-	emptyVerificationKeySetFunc jwt.Keyfunc = func(t *jwt.Token) (interface{}, error) {
+	emptyVerificationKeySetFunc jwt.Keyfunc = func(t *jwt.Token) (any, error) {
 		return jwt.VerificationKeySet{}, nil
 	}
 )

--- a/token.go
+++ b/token.go
@@ -11,9 +11,9 @@ import (
 // Token.  This allows you to use properties in the Header of the token (such as
 // `kid`) to identify which key to use.
 //
-// The returned interface{} may be a single key or a VerificationKeySet containing
+// The returned any may be a single key or a VerificationKeySet containing
 // multiple keys.
-type Keyfunc func(*Token) (interface{}, error)
+type Keyfunc func(*Token) (any, error)
 
 // VerificationKey represents a public or secret key for verifying a token's signature.
 type VerificationKey interface {


### PR DESCRIPTION
Hello, I replaced interface{} to its alias any in jwt.KeyFunc
<br>
```go
type Keyfunc func(*Token) (interface{}, error) // before
type Keyfunc func(*Token) (any, error)         // after
```