### PR TITLE
feat: use standard errors on MapClaims validation

### DIFF
--- a/map_claims.go
+++ b/map_claims.go
@@ -2,7 +2,6 @@ package jwt
 
 import (
 	"encoding/json"
-	"errors"
 	"time"
 	// "fmt"
 )
@@ -126,20 +125,17 @@ func (m MapClaims) Valid() error {
 	now := TimeFunc().Unix()
 
 	if !m.VerifyExpiresAt(now, false) {
-		// TODO(oxisto): this should be replaced with ErrTokenExpired
-		vErr.Inner = errors.New("Token is expired")
+		vErr.Inner = ErrTokenExpired
 		vErr.Errors |= ValidationErrorExpired
 	}
 
 	if !m.VerifyIssuedAt(now, false) {
-		// TODO(oxisto): this should be replaced with ErrTokenUsedBeforeIssued
-		vErr.Inner = errors.New("Token used before issued")
+		vErr.Inner = ErrTokenUsedBeforeIssued
 		vErr.Errors |= ValidationErrorIssuedAt
 	}
 
 	if !m.VerifyNotBefore(now, false) {
-		// TODO(oxisto): this should be replaced with ErrTokenNotValidYet
-		vErr.Inner = errors.New("Token is not valid yet")
+		vErr.Inner = ErrTokenNotValidYet
 		vErr.Errors |= ValidationErrorNotValidYet
 	}
 


### PR DESCRIPTION
Not sure if v4 still receives updates

But trying to handle proper the expiration errors in a project that uses `jwt/v4` when we want to identify the Token Expired error for example, as is a custom error we need to check by string comparison.

Just adding the proper exported standardized errors on MapClaims Valid().

---

This change can cause issues for users that have already created validations using a CamelCase string comparison when call `Parse()` like:

```go
token, err := jwt.Parse(tokenString, keyFunc{})
if strings.EqualFold(err, "Token is expired") {
    // handle error
} 
```

OR

```go
token, err := jwt.Parse(tokenString, keyFunc{})
if err.Error() == "Token is expired" {
    // handle error
} 
```

Since the standardized expired error uses lower case `t` and the current custom errors use upper case `T`