### PR TITLE
Feat: MapClaims Key Type-Safety

### DIFF
--- a/cmd/jwt/main.go
+++ b/cmd/jwt/main.go
@@ -192,7 +192,7 @@ func signToken() error {
 	// add command line claims
 	if len(flagClaims) > 0 {
 		for k, v := range flagClaims {
-			claims[k] = v
+			claims[jwt.ClaimsType(k)] = v
 		}
 	}
 

--- a/cmd/jwt/main.go
+++ b/cmd/jwt/main.go
@@ -192,7 +192,7 @@ func signToken() error {
 	// add command line claims
 	if len(flagClaims) > 0 {
 		for k, v := range flagClaims {
-			claims[jwt.ClaimsType(k)] = v
+			claims[jwt.MapClaimsKey(k)] = v
 		}
 	}
 

--- a/map_claims.go
+++ b/map_claims.go
@@ -5,19 +5,31 @@ import (
 	"fmt"
 )
 
+// ClaimsType is a type alias for claim keys in the [MapClaims] type.
 type ClaimsType string
 
 var (
+	// Exp is the "exp" claim key according to RFC 7519 section 4.1.4.
 	Exp ClaimsType = "exp"
+
+	// Nbf is the "nbf" claim key according to RFC 7519 section 4.1.5.
 	Nbf ClaimsType = "nbf"
+
+	// Iat is the "iat" claim key according to RFC 7519 section 4.1.6.
 	Iat ClaimsType = "iat"
+
+	// Aud is the "aud" claim key according to RFC 7519 section 4.1.3.
 	Aud ClaimsType = "aud"
+
+	// Iss is the "iss" claim key according to RFC 7519 section 4.1.1.
 	Iss ClaimsType = "iss"
+
+	// Sub is the "sub" claim key according to RFC 7519 section 4.1.2.
 	Sub ClaimsType = "sub"
 )
 
-// MapClaims is a claims type that uses the map[string]any for JSON
-// decoding. This is the default claims type if you don't supply one
+// MapClaims is a claims type that uses of map of [ClaimsType] with value [any]
+// for JSON decoding. This is the default claims type if you do not supply one.
 type MapClaims map[ClaimsType]any
 
 // GetExpirationTime implements the Claims interface.

--- a/map_claims.go
+++ b/map_claims.go
@@ -5,44 +5,55 @@ import (
 	"fmt"
 )
 
+type ClaimsType string
+
+var (
+	Exp ClaimsType = "exp"
+	Nbf ClaimsType = "nbf"
+	Iat ClaimsType = "iat"
+	Aud ClaimsType = "aud"
+	Iss ClaimsType = "iss"
+	Sub ClaimsType = "sub"
+)
+
 // MapClaims is a claims type that uses the map[string]any for JSON
 // decoding. This is the default claims type if you don't supply one
-type MapClaims map[string]any
+type MapClaims map[ClaimsType]any
 
 // GetExpirationTime implements the Claims interface.
 func (m MapClaims) GetExpirationTime() (*NumericDate, error) {
-	return m.parseNumericDate("exp")
+	return m.parseNumericDate(Exp)
 }
 
 // GetNotBefore implements the Claims interface.
 func (m MapClaims) GetNotBefore() (*NumericDate, error) {
-	return m.parseNumericDate("nbf")
+	return m.parseNumericDate(Nbf)
 }
 
 // GetIssuedAt implements the Claims interface.
 func (m MapClaims) GetIssuedAt() (*NumericDate, error) {
-	return m.parseNumericDate("iat")
+	return m.parseNumericDate(Iat)
 }
 
 // GetAudience implements the Claims interface.
 func (m MapClaims) GetAudience() (ClaimStrings, error) {
-	return m.parseClaimsString("aud")
+	return m.parseClaimsString(Aud)
 }
 
 // GetIssuer implements the Claims interface.
 func (m MapClaims) GetIssuer() (string, error) {
-	return m.parseString("iss")
+	return m.parseString(Iss)
 }
 
 // GetSubject implements the Claims interface.
 func (m MapClaims) GetSubject() (string, error) {
-	return m.parseString("sub")
+	return m.parseString(Sub)
 }
 
 // parseNumericDate tries to parse a key in the map claims type as a number
 // date. This will succeed, if the underlying type is either a [float64] or a
 // [json.Number]. Otherwise, nil will be returned.
-func (m MapClaims) parseNumericDate(key string) (*NumericDate, error) {
+func (m MapClaims) parseNumericDate(key ClaimsType) (*NumericDate, error) {
 	v, ok := m[key]
 	if !ok {
 		return nil, nil
@@ -66,7 +77,7 @@ func (m MapClaims) parseNumericDate(key string) (*NumericDate, error) {
 
 // parseClaimsString tries to parse a key in the map claims type as a
 // [ClaimsStrings] type, which can either be a string or an array of string.
-func (m MapClaims) parseClaimsString(key string) (ClaimStrings, error) {
+func (m MapClaims) parseClaimsString(key ClaimsType) (ClaimStrings, error) {
 	var cs []string
 	switch v := m[key].(type) {
 	case string:
@@ -89,7 +100,7 @@ func (m MapClaims) parseClaimsString(key string) (ClaimStrings, error) {
 // parseString tries to parse a key in the map claims type as a [string] type.
 // If the key does not exist, an empty string is returned. If the key has the
 // wrong type, an error is returned.
-func (m MapClaims) parseString(key string) (string, error) {
+func (m MapClaims) parseString(key ClaimsType) (string, error) {
 	var (
 		ok  bool
 		raw any

--- a/map_claims.go
+++ b/map_claims.go
@@ -5,32 +5,32 @@ import (
 	"fmt"
 )
 
-// ClaimsType is a type alias for claim keys in the [MapClaims] type.
-type ClaimsType string
+// MapClaimsKey is a type alias for claim keys in the [MapClaims] type.
+type MapClaimsKey string
 
 var (
 	// Exp is the "exp" claim key according to RFC 7519 section 4.1.4.
-	Exp ClaimsType = "exp"
+	Exp MapClaimsKey = "exp"
 
 	// Nbf is the "nbf" claim key according to RFC 7519 section 4.1.5.
-	Nbf ClaimsType = "nbf"
+	Nbf MapClaimsKey = "nbf"
 
 	// Iat is the "iat" claim key according to RFC 7519 section 4.1.6.
-	Iat ClaimsType = "iat"
+	Iat MapClaimsKey = "iat"
 
 	// Aud is the "aud" claim key according to RFC 7519 section 4.1.3.
-	Aud ClaimsType = "aud"
+	Aud MapClaimsKey = "aud"
 
 	// Iss is the "iss" claim key according to RFC 7519 section 4.1.1.
-	Iss ClaimsType = "iss"
+	Iss MapClaimsKey = "iss"
 
 	// Sub is the "sub" claim key according to RFC 7519 section 4.1.2.
-	Sub ClaimsType = "sub"
+	Sub MapClaimsKey = "sub"
 )
 
-// MapClaims is a claims type that uses of map of [ClaimsType] with value [any]
+// MapClaims is a claims type that uses of map of [MapClaimsKey] with value [any]
 // for JSON decoding. This is the default claims type if you do not supply one.
-type MapClaims map[ClaimsType]any
+type MapClaims map[MapClaimsKey]any
 
 // GetExpirationTime implements the Claims interface.
 func (m MapClaims) GetExpirationTime() (*NumericDate, error) {
@@ -65,7 +65,7 @@ func (m MapClaims) GetSubject() (string, error) {
 // parseNumericDate tries to parse a key in the map claims type as a number
 // date. This will succeed, if the underlying type is either a [float64] or a
 // [json.Number]. Otherwise, nil will be returned.
-func (m MapClaims) parseNumericDate(key ClaimsType) (*NumericDate, error) {
+func (m MapClaims) parseNumericDate(key MapClaimsKey) (*NumericDate, error) {
 	v, ok := m[key]
 	if !ok {
 		return nil, nil
@@ -89,7 +89,7 @@ func (m MapClaims) parseNumericDate(key ClaimsType) (*NumericDate, error) {
 
 // parseClaimsString tries to parse a key in the map claims type as a
 // [ClaimsStrings] type, which can either be a string or an array of string.
-func (m MapClaims) parseClaimsString(key ClaimsType) (ClaimStrings, error) {
+func (m MapClaims) parseClaimsString(key MapClaimsKey) (ClaimStrings, error) {
 	var cs []string
 	switch v := m[key].(type) {
 	case string:
@@ -112,7 +112,7 @@ func (m MapClaims) parseClaimsString(key ClaimsType) (ClaimStrings, error) {
 // parseString tries to parse a key in the map claims type as a [string] type.
 // If the key does not exist, an empty string is returned. If the key has the
 // wrong type, an error is returned.
-func (m MapClaims) parseString(key ClaimsType) (string, error) {
+func (m MapClaims) parseString(key MapClaimsKey) (string, error) {
 	var (
 		ok  bool
 		raw any

--- a/map_claims_example_test.go
+++ b/map_claims_example_test.go
@@ -1,0 +1,36 @@
+package jwt_test
+
+import (
+	"fmt"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+var (
+	// OpenIdConnectEMail represents the "email" claim as defined in
+	// OpenID Connect Core 1.0, section 5.1.
+	//
+	// Reference: https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+	OpenIdConnectEMail jwt.ClaimsType = "email"
+)
+
+// ExampleMapClaims shows how to create a token with custom claims using
+// [jwt.MapClaims] and the custom [jwt.ClaimsType].
+func ExampleMapClaims() {
+	claims := jwt.MapClaims{
+		"custom_claim":     "custom_value",
+		OpenIdConnectEMail: "me@example.com",
+		jwt.Sub:            "me",
+	}
+
+	t := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	s, err := t.SignedString([]byte("secret"))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(s)
+
+	// Output:
+	// eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjdXN0b21fY2xhaW0iOiJjdXN0b21fdmFsdWUiLCJlbWFpbCI6Im1lQGV4YW1wbGUuY29tIiwic3ViIjoibWUifQ.ylWqOBiOzsJpcJQarXmPtvgGMP9d72Zc2GtEdriqXko
+}

--- a/map_claims_example_test.go
+++ b/map_claims_example_test.go
@@ -11,11 +11,11 @@ var (
 	// OpenID Connect Core 1.0, section 5.1.
 	//
 	// Reference: https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
-	OpenIdConnectEMail jwt.ClaimsType = "email"
+	OpenIdConnectEMail jwt.MapClaimsKey = "email"
 )
 
 // ExampleMapClaims shows how to create a token with custom claims using
-// [jwt.MapClaims] and the custom [jwt.ClaimsType].
+// [jwt.MapClaims] and the custom [jwt.MapClaimsKey].
 func ExampleMapClaims() {
 	claims := jwt.MapClaims{
 		"custom_claim":     "custom_value",

--- a/map_claims_test.go
+++ b/map_claims_test.go
@@ -142,7 +142,7 @@ func TestMapClaimsVerifyExpiresAtExpire(t *testing.T) {
 
 func TestMapClaims_parseString(t *testing.T) {
 	type args struct {
-		key string
+		key ClaimsType
 	}
 	tests := []struct {
 		name    string

--- a/map_claims_test.go
+++ b/map_claims_test.go
@@ -142,7 +142,7 @@ func TestMapClaimsVerifyExpiresAtExpire(t *testing.T) {
 
 func TestMapClaims_parseString(t *testing.T) {
 	type args struct {
-		key ClaimsType
+		key MapClaimsKey
 	}
 	tests := []struct {
 		name    string


### PR DESCRIPTION
### I introduced this feature to improve type safety, preventing us from mistyping the string in MapClaims, thus providing a slightly better experience. Of course, with 5 minutes of research you already know what MapClaims expects, but with this safety feature, simply pressing ctrl+space shows developers the types it expects. 


### Before
<img width="775" height="348" alt="image" src="https://github.com/user-attachments/assets/121a3c78-77ba-483b-aebd-e3bdf3f0124c" />

### After
<img width="782" height="332" alt="image" src="https://github.com/user-attachments/assets/be630cbc-e208-46ab-ae16-4a6c635c45e6" />


---------
### I can blend the new way with the old way and it works.

<img width="782" height="365" alt="image" src="https://github.com/user-attachments/assets/3bc850a3-1584-438f-b11e-ee6a7a979da4" />

<img width="259" height="175" alt="image" src="https://github.com/user-attachments/assets/96d41689-ee89-4fe0-92f5-88496ddbe42c" />

---------

### ctrl+space

<img width="761" height="348" alt="image" src="https://github.com/user-attachments/assets/1017ed29-772e-4eb3-b794-cc46cc96cca6" />


