### PR TITLE
feat: Add helpers for setting `typ` and `cty` header parameters

### DIFF
--- a/token.go
+++ b/token.go
@@ -100,3 +100,30 @@ func (t *Token) SigningString() (string, error) {
 func (*Token) EncodeSegment(seg []byte) string {
 	return base64.RawURLEncoding.EncodeToString(seg)
 }
+
+// SetType sets the "typ" (type) header parameter.
+// According to https://datatracker.ietf.org/doc/html/rfc7519#section-5.1,
+// this parameter is optional.
+// Passing an empty string removes the parameter.
+func (t *Token) SetType(typ string) {
+	t.setHeaderParam("typ", typ)
+}
+
+// SetContentType sets the "cty" (content type) header parameter.
+// According to https://datatracker.ietf.org/doc/html/rfc7519#section-5.2,
+// this parameter is typically used when nested JWTs are present.
+// Passing an empty string removes the parameter.
+func (t *Token) SetContentType(cty string) {
+	t.setHeaderParam("cty", cty)
+}
+
+func (t *Token) setHeaderParam(k, v string) {
+	if t.Header == nil {
+		t.Header = make(map[string]any)
+	}
+	if v == "" {
+		delete(t.Header, k)
+		return
+	}
+	t.Header[k] = v
+}

--- a/token_test.go
+++ b/token_test.go
@@ -1,6 +1,9 @@
 package jwt_test
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -75,4 +78,76 @@ func BenchmarkToken_SigningString(b *testing.B) {
 			_, _ = t.SigningString()
 		}
 	})
+}
+
+func TestToken_SetType(t *testing.T) {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{})
+	token.SetType("at+jwt")
+	if token.Header["typ"] != "at+jwt" {
+		t.Errorf("Header[typ] = %v, want at+jwt", token.Header["typ"])
+	}
+
+	// Empty string removes typ
+	token.SetType("")
+	if _, ok := token.Header["typ"]; ok {
+		t.Error("SetType(\"\") should remove typ from header")
+	}
+}
+
+func TestToken_SetType_NilHeader(t *testing.T) {
+	token := &jwt.Token{Method: jwt.SigningMethodHS256, Claims: jwt.MapClaims{}}
+	token.SetType("JWT")
+	if token.Header == nil || token.Header["typ"] != "JWT" {
+		t.Errorf("SetType on nil Header: Header = %v", token.Header)
+	}
+}
+
+func TestToken_SetContentType(t *testing.T) {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{})
+	token.SetContentType("JWT")
+	if token.Header["cty"] != "JWT" {
+		t.Errorf("Header[cty] = %v, want JWT", token.Header["cty"])
+	}
+
+	// Empty string removes cty
+	token.SetContentType("")
+	if _, ok := token.Header["cty"]; ok {
+		t.Error("SetContentType(\"\") should remove cty from header")
+	}
+}
+
+func TestToken_SetContentType_NilHeader(t *testing.T) {
+	token := &jwt.Token{Method: jwt.SigningMethodHS256, Claims: jwt.MapClaims{}}
+	token.SetContentType("JWT")
+	if token.Header == nil || token.Header["cty"] != "JWT" {
+		t.Errorf("SetContentType on nil Header: Header = %v", token.Header)
+	}
+}
+
+func TestToken_SetType_SetContentType_InSigningString(t *testing.T) {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{})
+	token.SetType("at+jwt")
+	token.SetContentType("JWT")
+	sstr, err := token.SigningString()
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := strings.Split(sstr, ".")
+	if len(parts) != 2 {
+		t.Fatalf("SigningString has %d parts, want 2", len(parts))
+	}
+	headerJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var header map[string]any
+	if err := json.Unmarshal(headerJSON, &header); err != nil {
+		t.Fatal(err)
+	}
+	if header["typ"] != "at+jwt" {
+		t.Errorf("encoded header typ = %v, want at+jwt", header["typ"])
+	}
+	if header["cty"] != "JWT" {
+		t.Errorf("encoded header cty = %v, want JWT", header["cty"])
+	}
 }


### PR DESCRIPTION
Currently applications must mutate the `Token.Header` map directly to set header parameters `typ` [RFC7519 Section 5.1](https://datatracker.ietf.org/doc/html/rfc7519#section-5.1) and `cty` [RFC7519 Section 5.2](https://datatracker.ietf.org/doc/html/rfc7519#section-5.2).

Example:
```go
    token.Header["typ"] = "JWT"
```
This PR adds helper methods:
```go
    token.SetType("at+jwt")
    token.SetContentType("JWT")
```

These modify Token.Header internally and do not change signing or validation behavior.

This improves discoverability for these registered header parameters.

Happy to adjust naming or placement if a different approach is preferred.

Closes https://github.com/golang-jwt/jwt/issues/497

Related discussion: https://github.com/golang-jwt/jwt/issues/238
