### PR TITLE
Fix ParseUnverified returning error on malformed signature

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -193,10 +193,8 @@ func (p *Parser) ParseUnverified(tokenString string, claims Claims) (token *Toke
 	}
 
 	// Parse token signature
-	token.Signature, err = p.DecodeSegment(parts[2])
-	if err != nil {
-		return token, parts, newError("could not base64 decode signature", ErrTokenMalformed, err)
-	}
+	token.Signature, _ = p.DecodeSegment(parts[2])
+	// Ignore error: ParseUnverified does not validate the signature per documentation
 
 	return token, parts, nil
 }


### PR DESCRIPTION
## Problem

Since v5.3.1, `ParseUnverified` returns `ErrTokenMalformed` when base64 decoding the signature fails. This contradicts the documented behavior of not validating the signature.

Callers using `ParseUnverified` to inspect tokens without validation now get unexpected errors on tokens with malformed signatures.

## Solution

Ignore the `DecodeSegment` error for the signature portion in `ParseUnverified`, since the method explicitly should not care about signature validity.

Fixes #499