### PR TITLE
fix: treat exp=0 as expired (epoch time) instead of unset

### DIFF
--- a/map_claims.go
+++ b/map_claims.go
@@ -51,7 +51,7 @@ func (m MapClaims) parseNumericDate(key string) (*NumericDate, error) {
 	switch exp := v.(type) {
 	case float64:
 		if exp == 0 {
-			return nil, nil
+			return newNumericDateFromSeconds(0), nil
 		}
 
 		return newNumericDateFromSeconds(exp), nil


### PR DESCRIPTION
Fixes #496

## Problem

`MapClaims.parseNumericDate` has an inconsistency between `float64` and `json.Number` handling for the value `0`:

| Parse mode | `"exp": 0` result | Token expired? |
|---|---|---|
| Default (float64) | `nil` (claim not set) | No ❌ |
| WithJSONNumber() | epoch time (1970-01-01) | Yes ✅ |

Per RFC 7519, `exp: 0` means "expires at Unix epoch (1970-01-01)", which is always in the past.

## Fix

Change the `float64(0)` case to return `newNumericDateFromSeconds(0)` instead of `nil`, matching the `json.Number` behavior.

```go
// Before
case float64:
    if exp == 0 { return nil, nil }  // treated as "not set"

// After
case float64:
    if exp == 0 { return newNumericDateFromSeconds(0), nil }  // treated as epoch
```

All existing tests pass.