### PR TITLE
mapclaims: stop treating exp=0 as a missing claim

### DIFF
--- a/map_claims.go
+++ b/map_claims.go
@@ -50,10 +50,6 @@ func (m MapClaims) parseNumericDate(key string) (*NumericDate, error) {
 
 	switch exp := v.(type) {
 	case float64:
-		if exp == 0 {
-			return nil, nil
-		}
-
 		return newNumericDateFromSeconds(exp), nil
 	case json.Number:
 		v, _ := exp.Float64()

--- a/map_claims_test.go
+++ b/map_claims_test.go
@@ -216,3 +216,23 @@ func TestMapClaims_GetExpirationTime_ZeroIsExpired(t *testing.T) {
 		})
 	}
 }
+
+// A string exp must come back as ErrInvalidType, not as a stealth
+// "claim not present" via the old float64==0 shortcut. Empty string is
+// the case worth pinning down explicitly.
+func TestMapClaims_GetExpirationTime_StringIsInvalidType(t *testing.T) {
+	for name, claims := range map[string]MapClaims{
+		"empty string": {"exp": ""},
+		"non-empty":    {"exp": "foo"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := claims.GetExpirationTime()
+			if err == nil {
+				t.Fatalf("expected an error, got nil")
+			}
+			if !errors.Is(err, ErrInvalidType) {
+				t.Fatalf("expected ErrInvalidType, got %v", err)
+			}
+		})
+	}
+}

--- a/map_claims_test.go
+++ b/map_claims_test.go
@@ -1,6 +1,8 @@
 package jwt
 
 import (
+	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 )
@@ -188,6 +190,28 @@ func TestMapClaims_parseString(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("MapClaims.parseString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Regression for #496: a token whose exp claim is the literal 0 (i.e.
+// 1970-01-01) used to be treated as valid because parseNumericDate
+// special-cased a zero float64 as "claim not present". The json.Number
+// branch had no such carve-out, so the same token parsed via
+// WithJSONNumber() correctly came back expired.
+func TestMapClaims_GetExpirationTime_ZeroIsExpired(t *testing.T) {
+	for name, claims := range map[string]MapClaims{
+		"float64":     {"exp": float64(0)},
+		"json.Number": {"exp": json.Number("0")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := NewValidator().Validate(claims)
+			if err == nil {
+				t.Fatalf("expected an error for exp=0, got nil")
+			}
+			if !errors.Is(err, ErrTokenExpired) {
+				t.Fatalf("expected ErrTokenExpired, got %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #496.

`MapClaims.parseNumericDate` short-circuits and returns `nil` whenever a `float64` value is exactly 0. That made `\"exp\": 0` (a token that expired at the unix epoch) invisible to `verifyExpiresAt`, which checks for `exp == nil` and concludes the claim isn't set, so the token was accepted as valid.

The `json.Number` branch a few lines below had no such carve-out. Parsing the same payload via `WithJSONNumber()` came back correctly as expired, which is how the reporter discovered the inconsistency in the first place.

Removed the special case so both code paths agree: an `exp` of 0 returns a `NumericDate(0)` and the validator surfaces `ErrTokenExpired`.

Same logic applies to `nbf` and `iat` parsed from the same helper. `nbf=0` keeps meaning \"valid since the epoch\" (no behavior change in practice). `iat=0` now reports as 1970-01-01, which is what the spec says it is.

Added `TestMapClaims_GetExpirationTime_ZeroIsExpired` covering both the `float64` and `json.Number` paths.