### PR TITLE
fix: extended token expiry message with duration

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -182,7 +182,7 @@ func (v *Validator) verifyExpiresAt(claims Claims, cmp time.Time, required bool)
 		return errorIfRequired(required, "exp")
 	}
 
-	return errorIfFalse(cmp.Before((exp.Time).Add(+v.leeway)), ErrTokenExpired)
+	return errorIfFalse(cmp.Before((exp.Time).Add(+v.leeway)), fmt.Errorf("%w by %s", ErrTokenExpired, cmp.Sub(exp.Time).Truncate(time.Second)))
 }
 
 // verifyIssuedAt compares the iat claim in claims against cmp. This function

--- a/validator_test.go
+++ b/validator_test.go
@@ -2,6 +2,7 @@ package jwt
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 )
@@ -103,6 +104,7 @@ func Test_Validator_verifyExpiresAt(t *testing.T) {
 		fields  fields
 		args    args
 		wantErr error
+		wantBy  string
 	}{
 		{
 			name:    "good claim",
@@ -116,6 +118,19 @@ func Test_Validator_verifyExpiresAt(t *testing.T) {
 			args:    args{claims: MapClaims{"exp": "string"}},
 			wantErr: ErrInvalidType,
 		},
+		{
+			name:    "when leeway is in future",
+			fields:  fields{leeway: 10 * time.Minute},
+			args:    args{claims: RegisteredClaims{ExpiresAt: NewNumericDate(time.Now().Add(9 * time.Minute))}},
+			wantErr: nil,
+		},
+		{
+			name:    "when leeway is in the past",
+			fields:  fields{leeway: 10 * time.Minute},
+			args:    args{claims: RegisteredClaims{ExpiresAt: NewNumericDate(time.Now().Add(-15 * time.Minute))}, cmp: time.Now()},
+			wantErr: ErrTokenExpired,
+			wantBy:  "by 15m0s",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -125,8 +140,14 @@ func Test_Validator_verifyExpiresAt(t *testing.T) {
 			}
 
 			err := v.verifyExpiresAt(tt.args.claims, tt.args.cmp, tt.args.required)
-			if (err != nil) && !errors.Is(err, tt.wantErr) {
-				t.Errorf("validator.verifyExpiresAt() error = %v, wantErr %v", err, tt.wantErr)
+			if err != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("validator.verifyExpiresAt() error = %v, wantErr %v", err, tt.wantErr)
+				}
+
+				if errors.Is(err, ErrTokenExpired) && !strings.Contains(err.Error(), tt.wantBy) {
+					t.Errorf("Error string %q did not contain %q", err, tt.wantBy)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Prior to v5, the expiry validation error included the duration by which the token had expired (e.g. token is expired by 7m0s). 

This was removed in v5, losing useful debugging information.

This PR restores that behavior — the error message now includes the elapsed duration since expiry, making it easier to diagnose issues like clock skew or misconfigured TTLs without having to manually compare timestamps.

Before: `token is expired`
After:  `token is expired by 7m0s`
