### PR TITLE
fix: return ErrInvalidType for an invalid aud claim type in MapClaims

### DIFF
--- a/map_claims.go
+++ b/map_claims.go
@@ -77,6 +77,16 @@ func (m MapClaims) parseClaimsString(key string) (ClaimStrings, error) {
 			}
 			cs = append(cs, vs)
 		}
+	case nil:
+		// The claim is either absent or explicitly null. As the claim is
+		// optional, this is not an error and means "no value".
+		return nil, nil
+	default:
+		// Any other type (e.g. a number, boolean or object) is invalid, which
+		// is reported as an error to stay consistent with the other accessors
+		// such as parseString and parseNumericDate, as well as with the
+		// per-element type check performed on []any audiences above.
+		return nil, newError(fmt.Sprintf("%s is invalid", key), ErrInvalidType)
 	}
 
 	return cs, nil

--- a/map_claims_test.go
+++ b/map_claims_test.go
@@ -3,6 +3,7 @@ package jwt
 import (
 	"encoding/json"
 	"errors"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -232,6 +233,48 @@ func TestMapClaims_GetExpirationTime_StringIsInvalidType(t *testing.T) {
 			}
 			if !errors.Is(err, ErrInvalidType) {
 				t.Fatalf("expected ErrInvalidType, got %v", err)
+			}
+		})
+	}
+}
+
+func TestMapClaims_GetAudience(t *testing.T) {
+	tests := []struct {
+		name    string
+		m       MapClaims
+		want    ClaimStrings
+		wantErr bool
+	}{
+		// aud is optional: absent or null means "no audience", not an error.
+		{name: "missing aud", m: MapClaims{}, want: nil, wantErr: false},
+		{name: "null aud", m: MapClaims{"aud": nil}, want: nil, wantErr: false},
+		// Valid shapes per RFC 7519: a single string or an array of strings.
+		{name: "string aud", m: MapClaims{"aud": "example.com"}, want: ClaimStrings{"example.com"}, wantErr: false},
+		{name: "[]string aud", m: MapClaims{"aud": []string{"a", "b"}}, want: ClaimStrings{"a", "b"}, wantErr: false},
+		{name: "[]any of strings aud", m: MapClaims{"aud": []any{"a", "b"}}, want: ClaimStrings{"a", "b"}, wantErr: false},
+		// Invalid types must return ErrInvalidType, consistent with the other
+		// MapClaims accessors (iss/sub/exp/nbf/iat) and with the per-element
+		// check already performed on []any audiences.
+		{name: "[]any with non-string element", m: MapClaims{"aud": []any{"a", 5}}, want: nil, wantErr: true},
+		{name: "wrong type: number", m: MapClaims{"aud": 123}, want: nil, wantErr: true},
+		{name: "wrong type: bool", m: MapClaims{"aud": true}, want: nil, wantErr: true},
+		{name: "wrong type: object", m: MapClaims{"aud": map[string]any{"x": 1}}, want: nil, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.m.GetAudience()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MapClaims.GetAudience() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				if !errors.Is(err, ErrInvalidType) {
+					t.Errorf("MapClaims.GetAudience() error = %v, want errors.Is(err, ErrInvalidType)", err)
+				}
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MapClaims.GetAudience() = %#v, want %#v", got, tt.want)
 			}
 		})
 	}

--- a/map_claims_test.go
+++ b/map_claims_test.go
@@ -243,37 +243,31 @@ func TestMapClaims_GetAudience(t *testing.T) {
 		name    string
 		m       MapClaims
 		want    ClaimStrings
-		wantErr bool
+		wantErr error // nil means no error; otherwise errors.Is(err, wantErr)
 	}{
 		// aud is optional: absent or null means "no audience", not an error.
-		{name: "missing aud", m: MapClaims{}, want: nil, wantErr: false},
-		{name: "null aud", m: MapClaims{"aud": nil}, want: nil, wantErr: false},
+		{name: "missing aud", m: MapClaims{}, want: nil, wantErr: nil},
+		{name: "null aud", m: MapClaims{"aud": nil}, want: nil, wantErr: nil},
 		// Valid shapes per RFC 7519: a single string or an array of strings.
-		{name: "string aud", m: MapClaims{"aud": "example.com"}, want: ClaimStrings{"example.com"}, wantErr: false},
-		{name: "[]string aud", m: MapClaims{"aud": []string{"a", "b"}}, want: ClaimStrings{"a", "b"}, wantErr: false},
-		{name: "[]any of strings aud", m: MapClaims{"aud": []any{"a", "b"}}, want: ClaimStrings{"a", "b"}, wantErr: false},
+		{name: "string aud", m: MapClaims{"aud": "example.com"}, want: ClaimStrings{"example.com"}, wantErr: nil},
+		{name: "[]string aud", m: MapClaims{"aud": []string{"a", "b"}}, want: ClaimStrings{"a", "b"}, wantErr: nil},
+		{name: "[]any of strings aud", m: MapClaims{"aud": []any{"a", "b"}}, want: ClaimStrings{"a", "b"}, wantErr: nil},
 		// Invalid types must return ErrInvalidType, consistent with the other
 		// MapClaims accessors (iss/sub/exp/nbf/iat) and with the per-element
 		// check already performed on []any audiences.
-		{name: "[]any with non-string element", m: MapClaims{"aud": []any{"a", 5}}, want: nil, wantErr: true},
-		{name: "wrong type: number", m: MapClaims{"aud": 123}, want: nil, wantErr: true},
-		{name: "wrong type: bool", m: MapClaims{"aud": true}, want: nil, wantErr: true},
-		{name: "wrong type: object", m: MapClaims{"aud": map[string]any{"x": 1}}, want: nil, wantErr: true},
+		{name: "[]any with non-string element", m: MapClaims{"aud": []any{"a", 5}}, want: nil, wantErr: ErrInvalidType},
+		{name: "wrong type: number", m: MapClaims{"aud": 123}, want: nil, wantErr: ErrInvalidType},
+		{name: "wrong type: bool", m: MapClaims{"aud": true}, want: nil, wantErr: ErrInvalidType},
+		{name: "wrong type: object", m: MapClaims{"aud": map[string]any{"x": 1}}, want: nil, wantErr: ErrInvalidType},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.m.GetAudience()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("MapClaims.GetAudience() error = %v, wantErr %v", err, tt.wantErr)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("MapClaims.GetAudience() error = %v, want %v", err, tt.wantErr)
 				return
 			}
-			if tt.wantErr {
-				if !errors.Is(err, ErrInvalidType) {
-					t.Errorf("MapClaims.GetAudience() error = %v, want errors.Is(err, ErrInvalidType)", err)
-				}
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
+			if tt.wantErr == nil && !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("MapClaims.GetAudience() = %#v, want %#v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
## Problem

`MapClaims.parseClaimsString` (used by `MapClaims.GetAudience`) silently returns an empty audience and a `nil` error when the `aud` claim has an unexpected type such as a number, boolean or object:

```go
aud, err := jwt.MapClaims{"aud": 123}.GetAudience()
// before: aud == nil, err == nil   (silently swallowed)
```

This is inconsistent with the rest of the library:

- `parseString` (`iss`, `sub`) returns `ErrInvalidType` for a wrong type.
- `parseNumericDate` (`exp`, `nbf`, `iat`) returns `ErrInvalidType` for a wrong type.
- `parseClaimsString` itself already returns `ErrInvalidType` when an **element** of a `[]any` audience is not a string.
- `ClaimStrings.UnmarshalJSON` (the `RegisteredClaims` path) returns `ErrInvalidType` for the same input.

So a malformed `aud` scalar was the only claim that failed silently. The practical effect is a confusing diagnostic: with `WithAudience(...)` the validator reports `"aud is required"` (because the audience came back empty) instead of surfacing the actual invalid type. The token is still rejected, so this is not a security issue — it's a correctness/consistency fix that makes malformed tokens easier to debug.

## Fix

Add a `default` case to the type switch that returns `ErrInvalidType`, plus an explicit `nil` case so that an **absent or null** `aud` keeps meaning "no audience" (the claim is optional — no behaviour change there).

## Tests

Added `TestMapClaims_GetAudience`, a table test documenting the full contract (missing/null → no error; string/`[]string`/`[]any` → parsed; wrong element / wrong scalar type → `ErrInvalidType`). It fails before the change on the number/bool/object cases and passes after.

`go test -race ./...`, `go vet ./...` and `gofmt` are clean. No existing test changed.