### PR TITLE
fix: stop OAuth2Extractor from letting a non-Bearer header shadow access_token

### DIFF
--- a/request/oauth2.go
+++ b/request/oauth2.go
@@ -20,9 +20,11 @@ var AuthorizationHeaderExtractor = &PostExtractionFilter{
 	stripBearerPrefixFromTokenString,
 }
 
-// OAuth2Extractor is an Extractor for OAuth2 access tokens.  Looks in 'Authorization'
-// header then 'access_token' argument for a token.
+// OAuth2Extractor is an Extractor for OAuth2 access tokens. It looks for a
+// "Bearer" token in the 'Authorization' header, then for an 'access_token'
+// argument. A non-Bearer Authorization header (e.g. Basic auth) is ignored so
+// that it does not shadow a valid 'access_token' argument.
 var OAuth2Extractor = &MultiExtractor{
-	AuthorizationHeaderExtractor,
+	BearerExtractor{},
 	ArgumentExtractor{"access_token"},
 }

--- a/request/oauth2_test.go
+++ b/request/oauth2_test.go
@@ -1,0 +1,69 @@
+package request
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestOAuth2Extractor(t *testing.T) {
+	const fromHeader = "token-from-bearer-header"
+	const fromArg = "token-from-access_token-arg"
+
+	tests := []struct {
+		name    string
+		headers map[string]string
+		query   url.Values
+		want    string
+		wantErr error
+	}{
+		{
+			name:    "bearer header",
+			headers: map[string]string{"Authorization": "Bearer " + fromHeader},
+			want:    fromHeader,
+		},
+		{
+			name:    "bearer header takes precedence over access_token",
+			headers: map[string]string{"Authorization": "Bearer " + fromHeader},
+			query:   url.Values{"access_token": {fromArg}},
+			want:    fromHeader,
+		},
+		{
+			name:  "access_token when no authorization header",
+			query: url.Values{"access_token": {fromArg}},
+			want:  fromArg,
+		},
+		{
+			// Regression: a present but non-Bearer Authorization header (e.g.
+			// HTTP Basic) must not shadow a valid access_token argument.
+			name:    "non-bearer header falls through to access_token",
+			headers: map[string]string{"Authorization": "Basic dXNlcjpwYXNzd29yZA=="},
+			query:   url.Values{"access_token": {fromArg}},
+			want:    fromArg,
+		},
+		{
+			name:    "another non-bearer scheme falls through to access_token",
+			headers: map[string]string{"Authorization": "Token " + fromArg},
+			query:   url.Values{"access_token": {fromArg}},
+			want:    fromArg,
+		},
+		{
+			name:    "non-bearer header and no access_token",
+			headers: map[string]string{"Authorization": "Basic dXNlcjpwYXNzd29yZA=="},
+			want:    "",
+			wantErr: ErrNoTokenInRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := makeExampleRequest("GET", "/", tt.headers, tt.query)
+			got, err := OAuth2Extractor.ExtractToken(r)
+			if got != tt.want {
+				t.Errorf("token = %q, want %q", got, tt.want)
+			}
+			if err != tt.wantErr {
+				t.Errorf("err = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`OAuth2Extractor` is documented as "looks in 'Authorization' header then 'access_token' argument for a token". In practice, a present but **non-Bearer** `Authorization` header silently shadows a valid `access_token`:

```
Authorization: Basic dXNlcjpwYXNzd29yZA==   +   ?access_token=<valid JWT>
  -> OAuth2Extractor returns "Basic dXNlcjpwYXNzd29yZA==" (the access_token is never read)
```

The cause is the composition:

```go
var OAuth2Extractor = &MultiExtractor{
    AuthorizationHeaderExtractor, // returns ANY non-empty Authorization value
    ArgumentExtractor{"access_token"},
}
```

`AuthorizationHeaderExtractor`'s `stripBearerPrefixFromTokenString` returns the header value **unchanged** when there is no `"Bearer "` prefix, and `MultiExtractor` stops at the first non-empty token, so the `access_token` fallback only runs when the `Authorization` header is **entirely absent**. A request that carries both HTTP Basic auth (e.g. a browser re-sending cached credentials, or a proxy) and a valid `?access_token=<jwt>` therefore fails to authenticate, surfacing a confusing `token is malformed: token contains an invalid number of segments` error.

## Fix

Use `BearerExtractor{}` as the first sub-extractor. It already returns `ErrNoTokenInRequest` for a non-Bearer header, so `MultiExtractor` correctly falls through to `access_token`:

```go
var OAuth2Extractor = &MultiExtractor{
    BearerExtractor{},
    ArgumentExtractor{"access_token"},
}
```

## Behavior change

A token placed **directly** in the `Authorization` header **without** the `Bearer ` scheme prefix is no longer extracted by `OAuth2Extractor` (it previously was, as a side effect of the lenient strip). This matches RFC 6750, which mandates the `Bearer` scheme for OAuth2 access tokens. A real `Bearer <token>` header is unaffected, and `AuthorizationHeaderExtractor` itself is unchanged for anyone using it directly.

## Tests

Adds `TestOAuth2Extractor` covering: Bearer header, Bearer precedence over `access_token`, `access_token` fallback with no header, and the regression cases — a non-Bearer header (`Basic ...`, `Token ...`) falling through to `access_token`, and a non-Bearer header with no `access_token` returning `ErrNoTokenInRequest`. The fallthrough cases fail before this change and pass after.

`go test -race ./...`, `go vet ./...` and `gofmt` are clean; no existing test changed.