### PR TITLE
feat: add WithIssuedAtRequired parser option

### DIFF
--- a/parser_option.go
+++ b/parser_option.go
@@ -48,11 +48,21 @@ func WithTimeFunc(f func() time.Time) ParserOption {
 	}
 }
 
-// WithIssuedAt returns the ParserOption to enable verification
-// of issued-at.
+// WithIssuedAt returns the ParserOption to enable verification of issued-at
+// when the claim is present.
 func WithIssuedAt() ParserOption {
 	return func(p *Parser) {
 		p.validator.verifyIat = true
+	}
+}
+
+// WithIssuedAtRequired returns the ParserOption to make iat claim required.
+// By default iat claim is optional. This option also enables issued-at
+// verification.
+func WithIssuedAtRequired() ParserOption {
+	return func(p *Parser) {
+		p.validator.verifyIat = true
+		p.validator.requireIat = true
 	}
 }
 

--- a/validator.go
+++ b/validator.go
@@ -47,6 +47,9 @@ type Validator struct {
 	// requireNbf specifies whether the nbf claim is required
 	requireNbf bool
 
+	// requireIat specifies whether the iat claim is required
+	requireIat bool
+
 	// verifyIat specifies whether the iat (Issued At) claim will be verified.
 	// According to https://www.rfc-editor.org/rfc/rfc7519#section-4.1.6 this
 	// only specifies the age of the token, but no validation check is
@@ -122,7 +125,7 @@ func (v *Validator) Validate(claims Claims) error {
 
 	// Check issued-at if the option is enabled
 	if v.verifyIat {
-		if err = v.verifyIssuedAt(claims, now, false); err != nil {
+		if err = v.verifyIssuedAt(claims, now, v.requireIat); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/validator_test.go
+++ b/validator_test.go
@@ -329,6 +329,92 @@ func Test_Validator_requireNotBefore(t *testing.T) {
 	}
 }
 
+func Test_Validator_requireIssuedAt(t *testing.T) {
+	type fields struct {
+		leeway     time.Duration
+		timeFunc   func() time.Time
+		requireIat bool
+	}
+	type args struct {
+		claims Claims
+		cmp    time.Time
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr error
+	}{
+		{
+			name:    "good claim without iat",
+			fields:  fields{requireIat: false},
+			args:    args{claims: MapClaims{}},
+			wantErr: nil,
+		},
+		{
+			name:   "missing iat when required",
+			fields: fields{requireIat: true},
+			args:   args{claims: MapClaims{}},
+			wantErr: ErrTokenRequiredClaimMissing,
+		},
+		{
+			name:   "good claim with iat",
+			fields: fields{requireIat: true},
+			args: args{
+				claims: RegisteredClaims{IssuedAt: NewNumericDate(time.Now().Add(-10 * time.Minute))},
+				cmp:    time.Now(),
+			},
+			wantErr: nil,
+		},
+		{
+			name:   "token iat time is in future",
+			fields: fields{requireIat: true, timeFunc: time.Now},
+			args: args{
+				claims: RegisteredClaims{IssuedAt: NewNumericDate(time.Now().Add(10 * time.Minute))},
+				cmp:    time.Now(),
+			},
+			wantErr: ErrTokenUsedBeforeIssued,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := []ParserOption{
+				WithLeeway(tt.fields.leeway),
+				WithIssuedAt(),
+			}
+
+			if tt.fields.requireIat {
+				opts = append(opts, WithIssuedAtRequired())
+			}
+
+			if tt.fields.timeFunc != nil {
+				opts = append(opts, WithTimeFunc(tt.fields.timeFunc))
+			}
+
+			v := NewValidator(opts...)
+
+			cmp := tt.args.cmp
+			if cmp.IsZero() && tt.fields.timeFunc != nil {
+				cmp = tt.fields.timeFunc()
+			}
+			if cmp.IsZero() {
+				cmp = time.Now()
+			}
+
+			err := v.Validate(tt.args.claims)
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Errorf("validator.Validate() error = %v, wantErr nil", err)
+				}
+				return
+			}
+			if err == nil || !errors.Is(err, tt.wantErr) {
+				t.Errorf("validator.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func Test_Validator_verifyAudience(t *testing.T) {
 	type fields struct {
 		expectedAud []string


### PR DESCRIPTION
## Summary

Fixes #489  
Refs #411

Maintainers previously agreed not to change `WithIssuedAt()` semantics in v5 (validate only when present), and instead add a dedicated required option like `WithExpirationRequired` / `WithNotBeforeRequired`.

This PR adds:

- `requireIat` field on `Validator`
- `WithIssuedAtRequired()` parser option (enables iat verification and makes the claim mandatory)
- `Validate()` now passes `v.requireIat` to `verifyIssuedAt`
- Tests covering optional vs required iat behavior

Usage for callers who need a mandatory `iat` claim:

```go
jwt.Parse(tokenString, keyfunc,
    jwt.WithIssuedAtRequired(),
    jwt.WithAudience(expectedAudience),
)
```

## Test plan

- [x] `go test ./...`