### PR TITLE
fix(parser): ignore malformed signature in ParseUnverified

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -192,11 +192,9 @@ func (p *Parser) ParseUnverified(tokenString string, claims Claims) (token *Toke
 		return token, parts, newError("signing method (alg) is unspecified", ErrTokenUnverifiable)
 	}
 
-	// Parse token signature
-	token.Signature, err = p.DecodeSegment(parts[2])
-	if err != nil {
-		return token, parts, newError("could not base64 decode signature", ErrTokenMalformed, err)
-	}
+	// Parse token signature. Signature validation is intentionally skipped in
+	// ParseUnverified; a malformed signature segment must not fail parsing.
+	token.Signature, _ = p.DecodeSegment(parts[2])
 
 	return token, parts, nil
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -637,6 +638,36 @@ func TestParser_ParseUnverified(t *testing.T) {
 				t.Errorf("[%v] Token.Signature field mismatch. Expecting non-nil, got %v", data.name, token.Signature)
 			}
 		})
+	}
+}
+
+func TestParser_ParseUnverifiedIgnoresMalformedSignature(t *testing.T) {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{"sub": "1234567890"})
+	tokenString, err := token.SignedString([]byte("secret"))
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+
+	parts := strings.Split(tokenString, ".")
+	if len(parts) != 3 {
+		t.Fatalf("unexpected token parts: %d", len(parts))
+	}
+	malformedSignatureToken := parts[0] + "." + parts[1] + ".!!!"
+
+	parsed, _, err := jwt.NewParser().ParseUnverified(malformedSignatureToken, jwt.MapClaims{})
+	if err != nil {
+		t.Fatalf("ParseUnverified returned error: %v", err)
+	}
+
+	claims, ok := parsed.Claims.(jwt.MapClaims)
+	if !ok {
+		t.Fatalf("unexpected claims type %T", parsed.Claims)
+	}
+	if claims["sub"] != "1234567890" {
+		t.Fatalf("unexpected sub claim: %v", claims["sub"])
+	}
+	if len(parsed.Signature) != 0 {
+		t.Fatalf("expected empty signature bytes, got %v", parsed.Signature)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `ParseUnverified` no longer fails when the signature segment cannot be base64url-decoded
- Malformed signature bytes are treated as absent signature data, matching the method's documented contract of not validating signatures
- Restores behavior expected by callers that only need claims from tokens whose signature segment is corrupted or intentionally ignored

## Problem

Since v5.3.1, `ParseUnverified` returns `ErrTokenMalformed` when the signature segment is invalid base64. That is stricter than the documented behavior ("does not validate the signature") and breaks callers that previously could still read claims from such tokens.

## Test plan

- [x] Added `TestParser_ParseUnverifiedIgnoresMalformedSignature`
- [x] `go test ./...`

Fixes #499