### PR TITLE
feat: add required issued-at validation option

### DIFF
--- a/map_claims_test.go
+++ b/map_claims_test.go
@@ -90,6 +90,15 @@ func TestMapclaimsVerifyIssuedAtInvalidTypeString(t *testing.T) {
 	}
 }
 
+func TestMapclaimsVerifyIssuedAtRequired(t *testing.T) {
+	mapClaims := MapClaims{}
+	want := false
+	got := NewValidator(WithIssuedAtRequired()).Validate(mapClaims)
+	if want != (got == nil) {
+		t.Fatalf("Failed to verify required iat claim, wanted: %v got %v", want, (got == nil))
+	}
+}
+
 func TestMapclaimsVerifyNotBeforeInvalidTypeString(t *testing.T) {
 	mapClaims := MapClaims{
 		"nbf": "foo",

--- a/parser_option.go
+++ b/parser_option.go
@@ -56,6 +56,15 @@ func WithIssuedAt() ParserOption {
 	}
 }
 
+// WithIssuedAtRequired returns the ParserOption to make the iat claim
+// required. Enabling this option also enables issued-at verification.
+func WithIssuedAtRequired() ParserOption {
+	return func(p *Parser) {
+		p.validator.verifyIat = true
+		p.validator.requireIat = true
+	}
+}
+
 // WithExpirationRequired returns the ParserOption to make exp claim required.
 // By default exp claim is optional.
 func WithExpirationRequired() ParserOption {

--- a/validator.go
+++ b/validator.go
@@ -54,6 +54,10 @@ type Validator struct {
 	// unrealistic, i.e., in the future.
 	verifyIat bool
 
+	// requireIat specifies whether the iat claim is required when iat
+	// verification is enabled.
+	requireIat bool
+
 	// expectedAud contains the audience this token expects. Supplying an empty
 	// slice will disable aud checking.
 	expectedAud []string
@@ -122,7 +126,7 @@ func (v *Validator) Validate(claims Claims) error {
 
 	// Check issued-at if the option is enabled
 	if v.verifyIat {
-		if err = v.verifyIssuedAt(claims, now, false); err != nil {
+		if err = v.verifyIssuedAt(claims, now, v.requireIat); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/validator_test.go
+++ b/validator_test.go
@@ -240,6 +240,7 @@ func Test_Validator_verifyIssuedAt(t *testing.T) {
 		leeway    time.Duration
 		timeFunc  func() time.Time
 		verifyIat bool
+		requireIat bool
 	}
 	type args struct {
 		claims   Claims
@@ -260,13 +261,19 @@ func Test_Validator_verifyIssuedAt(t *testing.T) {
 		},
 		{
 			name:   "good claim with iat",
-			fields: fields{verifyIat: true},
+			fields: fields{verifyIat: true, requireIat: true},
 			args: args{
 				claims:   RegisteredClaims{IssuedAt: NewNumericDate(time.Now())},
 				cmp:      time.Now().Add(10 * time.Minute),
-				required: false,
+				required: true,
 			},
 			wantErr: nil,
+		},
+		{
+			name:    "required iat missing",
+			fields:  fields{verifyIat: true, requireIat: true},
+			args:    args{claims: MapClaims{}, required: true},
+			wantErr: ErrTokenRequiredClaimMissing,
 		},
 	}
 	for _, tt := range tests {
@@ -275,6 +282,7 @@ func Test_Validator_verifyIssuedAt(t *testing.T) {
 				leeway:    tt.fields.leeway,
 				timeFunc:  tt.fields.timeFunc,
 				verifyIat: tt.fields.verifyIat,
+				requireIat: tt.fields.requireIat,
 			}
 			if err := v.verifyIssuedAt(tt.args.claims, tt.args.cmp, tt.args.required); (err != nil) && !errors.Is(err, tt.wantErr) {
 				t.Errorf("validator.verifyIssuedAt() error = %v, wantErr %v", err, tt.wantErr)

--- a/validator_test.go
+++ b/validator_test.go
@@ -239,7 +239,7 @@ func Test_Validator_verifyIssuedAt(t *testing.T) {
 	type fields struct {
 		leeway    time.Duration
 		timeFunc  func() time.Time
-		verifyIat bool
+		verifyIat  bool
 		requireIat bool
 	}
 	type args struct {
@@ -279,9 +279,9 @@ func Test_Validator_verifyIssuedAt(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			v := &Validator{
-				leeway:    tt.fields.leeway,
-				timeFunc:  tt.fields.timeFunc,
-				verifyIat: tt.fields.verifyIat,
+				leeway:     tt.fields.leeway,
+				timeFunc:   tt.fields.timeFunc,
+				verifyIat:  tt.fields.verifyIat,
 				requireIat: tt.fields.requireIat,
 			}
 			if err := v.verifyIssuedAt(tt.args.claims, tt.args.cmp, tt.args.required); (err != nil) && !errors.Is(err, tt.wantErr) {


### PR DESCRIPTION
## Summary
- add `WithIssuedAtRequired()` to require the `iat` claim while also enabling issued-at validation
- thread the new `requireIat` validator setting through claim validation
- add regression tests for missing required `iat` claims

## Why
Issue #489 points out that `WithIssuedAt()` validates future `iat` values but still leaves the claim optional, unlike the existing required-claim options such as `WithExpirationRequired()` and `WithNotBeforeRequired()`.

This change keeps the current `WithIssuedAt()` behavior intact for callers that only want the sanity check, while providing an explicit option for callers that want `iat` to be mandatory.

Closes #489
