### PR TITLE
fix: enable IssuedAt verification when WithIssuedAt() is used

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -122,7 +122,7 @@ func (v *Validator) Validate(claims Claims) error {
 
 	// Check issued-at if the option is enabled
 	if v.verifyIat {
-		if err = v.verifyIssuedAt(claims, now, false); err != nil {
+		if err = v.verifyIssuedAt(claims, now, true); err != nil {
 			errs = append(errs, err)
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes #489

The `verifyIssuedAt` call in the validator was passing `false` for the `required` parameter, which means IssuedAt would never actually be verified even when `WithIssuedAt()` was used by the caller.

## Root Cause

In `validator.go`, the IssuedAt check is:

```go
if v.verifyIat {
    if err = v.verifyIssuedAt(claims, now, false); err != nil {
```

The third parameter `required` controls whether the check is enforced. Passing `false` means the function only checks if the claim *exists* but doesn't actually validate it. Passing `true` enforces the check.

## Changes

Changed `false` to `true` so that `WithIssuedAt()` actually enforces IssuedAt validation.

This is a one-character fix.