### PR TITLE
feat: add SetType and SetContentType helpers for Token

### DIFF
--- a/token.go
+++ b/token.go
@@ -100,3 +100,15 @@ func (t *Token) SigningString() (string, error) {
 func (*Token) EncodeSegment(seg []byte) string {
 	return base64.RawURLEncoding.EncodeToString(seg)
 }
+
+// SetType sets the "typ" (Type) header parameter as defined in RFC 7519 Section 5.1.
+// Common values include "JWT", "at+jwt", etc.
+func (t *Token) SetType(typ string) {
+	t.Header["typ"] = typ
+}
+
+// SetContentType sets the "cty" (Content Type) header parameter as defined in RFC 7519 Section 5.2.
+// This is used to declare the media type of the content in nested JWTs.
+func (t *Token) SetContentType(cty string) {
+	t.Header["cty"] = cty
+}


### PR DESCRIPTION
## Summary

Closes #497

Adds `Token.SetType(typ)` and `Token.SetContentType(cty)` convenience methods for setting the `"typ"` and `"cty"` header parameters defined in RFC 7519 Sections 5.1 and 5.2.

## Motivation

Currently, applications must mutate `Token.Header` directly to set these registered header parameters:

```go
token.Header["typ"] = "at+jwt"
token.Header["cty"] = "JWT"
```

This is error-prone (typos in key names) and doesn't help with discoverability of these standard parameters.

## Changes

Added two small helper methods:

```go
func (t *Token) SetType(typ string)       // sets Header["typ"]
func (t *Token) SetContentType(cty string) // sets Header["cty"]
```

These simply modify `Token.Header` internally and do not change signing or validation behavior.